### PR TITLE
chore: update repo URLs to imnsco/DurableWS after transfer

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question / discussion
-    url: https://github.com/imns/durablews/discussions
+    url: https://github.com/imnsco/DurableWS/discussions
     about: Ask questions and discuss ideas in Discussions.
   - name: Report a security vulnerability
-    url: https://github.com/imns/durablews/security/advisories/new
+    url: https://github.com/imnsco/DurableWS/security/advisories/new
     about: Please report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Before filing, please check the [v2 architecture RFC](https://github.com/imns/durablews/blob/main/docs/rfc/0001-v2-architecture.md) — your idea may already be planned.
+        Before filing, please check the [v2 architecture RFC](https://github.com/imnsco/DurableWS/blob/main/docs/rfc/0001-v2-architecture.md) — your idea may already be planned.
   - type: textarea
     id: problem
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for your interest in contributing! DurableWS is being built in the open, 
 ## Getting started
 
 ```bash
-git clone https://github.com/imns/durablews.git
+git clone https://github.com/imnsco/DurableWS.git
 cd durablews
 pnpm install        # installs deps and sets up the git hooks
 ```

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "license": "MPL-2.0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/imns/durablews.git"
+        "url": "https://github.com/imnsco/DurableWS.git"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.4.16",

--- a/packages/durablews/README.md
+++ b/packages/durablews/README.md
@@ -2,7 +2,7 @@
 
 > A resilient, modern, zero-dependency WebSocket **client** for TypeScript — built on the standard `WebSocket`, durable by default, and the same in every modern runtime.
 
-> ⚠️ **v2 is under active development (`2.0.0-alpha`).** The API is changing and several headline features below are still being built. See the [v2 architecture RFC](https://github.com/imns/durablews/blob/main/docs/rfc/0001-v2-architecture.md) for the design and live status. The current npm release (`1.x`) predates this redesign.
+> ⚠️ **v2 is under active development (`2.0.0-alpha`).** The API is changing and several headline features below are still being built. See the [v2 architecture RFC](https://github.com/imnsco/DurableWS/blob/main/docs/rfc/0001-v2-architecture.md) for the design and live status. The current npm release (`1.x`) predates this redesign.
 
 DurableWS aims to be "the Hono of WebSockets": tiny, ergonomic, Web-Standards-based, and **durable by default** — automatic reconnection, message queueing, and idle detection out of the box — with a middleware + codec pipeline for extensibility (custom wire formats, auth, a socket.io-compatibility layer, and more).
 
@@ -62,12 +62,12 @@ client.close();
 
 ## Documentation
 
-- [v2 architecture RFC](https://github.com/imns/durablews/blob/main/docs/rfc/0001-v2-architecture.md)
+- [v2 architecture RFC](https://github.com/imnsco/DurableWS/blob/main/docs/rfc/0001-v2-architecture.md)
 - A full documentation site (Astro + Starlight) is coming as part of v2.
 
 ## Contributing
 
-Contributions are welcome — see [CONTRIBUTING](https://github.com/imns/durablews/blob/main/CONTRIBUTING.md).
+Contributions are welcome — see [CONTRIBUTING](https://github.com/imnsco/DurableWS/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -39,13 +39,13 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/imns/durablews.git",
+        "url": "git+https://github.com/imnsco/DurableWS.git",
         "directory": "packages/durablews"
     },
     "bugs": {
-        "url": "https://github.com/imns/durablews/issues"
+        "url": "https://github.com/imnsco/DurableWS/issues"
     },
-    "homepage": "https://github.com/imns/durablews#readme",
+    "homepage": "https://github.com/imnsco/DurableWS#readme",
     "keywords": [
         "websocket",
         "typescript",


### PR DESCRIPTION
Updates all hardcoded `imns/durablews` references to `imnsco/DurableWS` following the repo transfer (package manifests, READMEs, CONTRIBUTING, issue templates). No code changes.