### PR TITLE
ci: split CI into named jobs; rename gate script to verify

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Closes #
 ## Checklist
 
 - [ ] Tests added/updated (assert on observable behavior, not just that an event fired)
-- [ ] `pnpm ci` passes locally (Biome, typecheck, build, tests, publish validation)
+- [ ] `pnpm verify` passes locally (Biome, typecheck, build, tests, publish validation)
 - [ ] Changeset added if this affects the published package (`pnpm changeset`)
 - [ ] Docs / README / RFC updated if behavior or the plan changed
 - [ ] Conventional commit messages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  verify:
-    name: Verify (Node ${{ matrix.node }})
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Biome
+        run: pnpm exec biome ci .
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: tsc --noEmit
+        run: pnpm -F durablews typecheck
+
+  test:
+    name: Test (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -20,30 +54,33 @@ jobs:
         node: [22, 24]
     steps:
       - uses: actions/checkout@v4
-
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-
       - name: Setup Node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Lint (Biome)
-        run: pnpm exec biome ci .
-
-      - name: Typecheck
-        run: pnpm -F durablews typecheck
-
-      - name: Build
-        run: pnpm -F durablews build
-
-      - name: Test
+      - name: Run tests
         run: pnpm -F durablews test:run
 
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm -F durablews build
       - name: Validate publish (publint + attw)
         run: pnpm -F durablews check:publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,12 @@ pnpm -F durablews build      # tsup build
 pnpm typecheck               # tsc --noEmit
 pnpm lint                    # Biome check
 pnpm format                  # Biome format (write)
-pnpm ci                      # run the full CI gate locally
+pnpm verify                      # run the full CI gate locally
 ```
 
 - **Formatting & linting** is handled by [Biome](https://biomejs.dev). A [lefthook](https://lefthook.dev) pre-commit hook runs Biome on staged files automatically, so commits stay formatted.
 - **Tests** use [Vitest](https://vitest.dev). New behavior needs tests; assert on observable state/outcomes, not merely that an event fired.
-- **CI** runs Biome, typecheck, build, tests, and publish validation (publint + are-the-types-wrong) on Node 22 and 24. Run `pnpm ci` before pushing.
+- **CI** runs Biome, typecheck, build, tests, and publish validation (publint + are-the-types-wrong) on Node 22 and 24. Run `pnpm verify` before pushing.
 
 ## Commit messages
 
@@ -53,7 +53,7 @@ Pick the appropriate semver bump and write a short, user-facing summary. Tooling
 
 1. Branch from `main`.
 2. Make your change with tests and (if user-facing) a changeset.
-3. Ensure `pnpm ci` passes.
+3. Ensure `pnpm verify` passes.
 4. Open a PR against `main` and fill out the template.
 
 ## Plugins & add-ons

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pnpm -F durablews build   # tsup build (ESM + CJS + types)
 pnpm typecheck            # tsc --noEmit
 pnpm lint                 # Biome
 pnpm format               # Biome (write)
-pnpm ci                   # everything CI runs, locally
+pnpm verify               # everything CI runs, locally
 ```
 
 Commits are formatted automatically by a [lefthook](https://lefthook.dev) pre-commit hook (Biome). Versioning and releases use [changesets](https://github.com/changesets/changesets).

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "lint": "biome check .",
         "format": "biome format --write .",
         "check:publish": "pnpm -F durablews check:publish",
-        "ci": "biome ci . && pnpm typecheck && pnpm build && pnpm test:run && pnpm check:publish",
+        "verify": "biome ci . && pnpm typecheck && pnpm build && pnpm test:run && pnpm check:publish",
         "changeset": "changeset",
         "release:version": "changeset version",
         "release:publish": "pnpm build && changeset publish",


### PR DESCRIPTION
Splits the matrixed `Verify (Node XX)` job into **Lint**, **Typecheck**, **Test (Node 22/24)**, and **Package** so check names communicate what's verified. Renames the `ci` script to `verify` (since `pnpm ci` is shadowed by pnpm's install) and fixes the docs.

⚠️ After this merges, the branch ruleset's required status checks must be updated to: Lint, Typecheck, Test (Node 22), Test (Node 24), Package. (Handled as part of landing this.)