### PR TITLE
feat(core): re-home the middleware pipeline (M2 slice 3)

### DIFF
--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -52,11 +52,12 @@ client.close();
   `error`, `statechange`) via `on()`
 - A read-only `state` and `getState()` snapshot
 - A pluggable wire-format codec (`codec` option; JSON by default)
+- A message middleware pipeline (`use()`), with an opt-in `pingpong` keepalive
 
 ## On the roadmap
 
-A middleware pipeline, automatic reconnection with exponential backoff, message
-queueing while disconnected, idle detection, and channels. Until these land,
-treat the durability features as a roadmap rather than a guarantee — see the
+Automatic reconnection with exponential backoff, message queueing while
+disconnected, idle detection, and channels. Until these land, treat the
+durability features as a roadmap rather than a guarantee — see the
 [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
 for the full plan and status.

--- a/packages/durablews/src/client.ts
+++ b/packages/durablews/src/client.ts
@@ -1,11 +1,13 @@
 import { jsonCodec } from "@/codec";
 import { nextState } from "@/fsm";
 import { defineEventBus } from "@/helpers/event-bus";
+import { runPipeline } from "@/pipeline";
 import type {
     ClientEventMap,
     ClientState,
     ConnectionEvent,
     ConnectionState,
+    Middleware,
     WebSocketClient,
     WebSocketClientConfig
 } from "@/types";
@@ -30,6 +32,7 @@ import type {
 export function client(config: WebSocketClientConfig): WebSocketClient {
     const bus = defineEventBus();
     const codec = config.codec ?? jsonCodec;
+    const middlewares: Middleware[] = [];
 
     let socket: WebSocket | null = null;
     let state: ConnectionState = "idle";
@@ -83,7 +86,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         };
 
         socket.onmessage = (event: MessageEvent) => {
-            bus.emit("message", codec.decode(event.data));
+            deliver(event.data);
         };
 
         socket.onerror = (event: Event) => {
@@ -110,7 +113,29 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         };
     }
 
-    return {
+    /**
+     * Runs a decoded inbound message through the middleware chain. If the chain
+     * completes, the message is emitted as `message`; a middleware that throws
+     * or rejects surfaces as an `error`.
+     */
+    function deliver(raw: unknown) {
+        const ctx = { data: codec.decode(raw), client: api };
+        const emit = () => {
+            bus.emit("message", ctx.data);
+        };
+        try {
+            const result = runPipeline(middlewares, ctx, emit);
+            if (result instanceof Promise) {
+                result.catch((error: unknown) => {
+                    bus.emit("error", toError(error));
+                });
+            }
+        } catch (error) {
+            bus.emit("error", toError(error));
+        }
+    }
+
+    const api: WebSocketClient = {
         get state() {
             return state;
         },
@@ -177,8 +202,20 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
             return () => bus.off(event, handler);
         },
 
+        use(middleware: Middleware) {
+            middlewares.push(middleware);
+            return api;
+        },
+
         getState(): ClientState {
             return Object.freeze({ state, lastError });
         }
     };
+
+    return api;
+}
+
+/** Normalize an unknown thrown value into an `Error`. */
+function toError(value: unknown): Error {
+    return value instanceof Error ? value : new Error(String(value));
 }

--- a/packages/durablews/src/index.ts
+++ b/packages/durablews/src/index.ts
@@ -17,11 +17,14 @@ export function defineClient(config: WebSocketClientConfig): WebSocketClient {
 }
 
 export { jsonCodec } from "@/codec";
+export { pingpong } from "@/middleware";
 export type {
     ClientEventMap,
     ClientState,
     Codec,
     ConnectionState,
+    MessageContext,
+    Middleware,
     StateChange,
     WebSocketClient,
     WebSocketClientConfig

--- a/packages/durablews/src/middleware.ts
+++ b/packages/durablews/src/middleware.ts
@@ -1,0 +1,21 @@
+import type { Middleware } from "@/types";
+
+/**
+ * Replies to a textual `"ping"` with `"pong"` and stops the message there
+ * (it is not emitted as a `message` event). A common keepalive convention.
+ *
+ * Opt in explicitly — it is not registered by default:
+ *
+ * ```typescript
+ * import { defineClient, pingpong } from "durablews";
+ *
+ * const ws = defineClient({ url }).use(pingpong);
+ * ```
+ */
+export const pingpong: Middleware = (ctx, next) => {
+    if (ctx.data === "ping") {
+        ctx.client.send("pong");
+        return;
+    }
+    return next();
+};

--- a/packages/durablews/src/pipeline.ts
+++ b/packages/durablews/src/pipeline.ts
@@ -1,0 +1,35 @@
+import type { MessageContext, Middleware } from "@/types";
+
+/**
+ * Runs an inbound message through the middleware chain (onion model).
+ *
+ * Each middleware receives the shared context and a `next` it may call to pass
+ * control onward. When the chain runs to completion, `terminal` is invoked —
+ * this is where the client emits the `message` event. A middleware that returns
+ * without calling `next()` short-circuits the chain (and `terminal`).
+ *
+ * Mirrors the guard from the old store pipeline: calling `next()` more than once
+ * in a single middleware is a bug and throws.
+ *
+ * @returns `void`, or a `Promise` if any middleware in the chain is async.
+ */
+export function runPipeline(
+    middlewares: readonly Middleware[],
+    ctx: MessageContext,
+    terminal: () => void
+): void | Promise<void> {
+    let invoked = -1;
+
+    function dispatch(i: number): void | Promise<void> {
+        if (i <= invoked) {
+            throw new Error("next() called multiple times");
+        }
+        invoked = i;
+
+        const middleware = middlewares[i];
+        if (!middleware) return terminal();
+        return middleware(ctx, () => dispatch(i + 1));
+    }
+
+    return dispatch(0);
+}

--- a/packages/durablews/src/types.ts
+++ b/packages/durablews/src/types.ts
@@ -64,6 +64,32 @@ export interface ClientState {
 }
 
 /**
+ * The context handed to each message middleware.
+ */
+export interface MessageContext {
+    /**
+     * The decoded inbound message. Middleware may reassign this to transform
+     * what later middleware — and the `message` event — receive.
+     */
+    data: unknown;
+    /** The client, e.g. for sending a reply from within the pipeline. */
+    readonly client: WebSocketClient;
+}
+
+/**
+ * Message middleware, run in registration order for each inbound message.
+ *
+ * Call `next()` to pass control to the next middleware; the message is emitted
+ * as a `message` event only if the whole chain calls through. Return without
+ * calling `next()` to short-circuit (e.g. an auto-reply that shouldn't bubble).
+ * May be async.
+ */
+export type Middleware = (
+    ctx: MessageContext,
+    next: () => void | Promise<void>
+) => void | Promise<void>;
+
+/**
  * Payload emitted on every `statechange`.
  */
 export interface StateChange {
@@ -84,8 +110,11 @@ export interface ClientEventMap {
     message: unknown;
     /** The socket closed (clean or otherwise). */
     close: CloseEvent;
-    /** A transport error occurred. */
-    error: Event;
+    /**
+     * Something failed: a transport error (an `Event` from the socket) or a
+     * middleware that threw/rejected (an `Error`).
+     */
+    error: Event | Error;
     /** The connection state changed. */
     statechange: StateChange;
 }
@@ -132,6 +161,12 @@ export interface WebSocketClient {
         event: K,
         handler: (payload: ClientEventMap[K]) => void
     ): () => void;
+
+    /**
+     * Registers message middleware, run in order for each inbound message.
+     * @returns the client, for chaining.
+     */
+    use(middleware: Middleware): WebSocketClient;
 
     /**
      * Returns a read-only snapshot of the client's observable state.

--- a/packages/durablews/tests/client.test.ts
+++ b/packages/durablews/tests/client.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // https://github.com/akiomik/vitest-websocket-mock
 import WS from "vitest-websocket-mock";
 import { client } from "../src/client";
-import type { WebSocketClient } from "../src/types";
+import { pingpong } from "../src/middleware";
+import type { Middleware, WebSocketClient } from "../src/types";
 
 const URL = "ws://localhost:1234";
 
@@ -115,6 +116,79 @@ describe("client", () => {
         custom.on("message", onMessage);
         customServer.send("raw");
         expect(onMessage).toHaveBeenCalledWith("decoded:raw");
+    });
+
+    it("runs middleware for each inbound message, then emits message", async () => {
+        const seen: unknown[] = [];
+        ws.use((ctx, next) => {
+            seen.push(ctx.data);
+            return next();
+        });
+        const onMessage = vi.fn();
+        ws.on("message", onMessage);
+
+        await connected();
+        server.send(JSON.stringify({ n: 1 }));
+
+        expect(seen).toEqual([{ n: 1 }]);
+        expect(onMessage).toHaveBeenCalledWith({ n: 1 });
+    });
+
+    it("middleware can transform the emitted message", async () => {
+        ws.use((ctx, next) => {
+            ctx.data = { ...(ctx.data as object), tagged: true };
+            return next();
+        });
+        const onMessage = vi.fn();
+        ws.on("message", onMessage);
+
+        await connected();
+        server.send(JSON.stringify({ n: 1 }));
+
+        expect(onMessage).toHaveBeenCalledWith({ n: 1, tagged: true });
+    });
+
+    it("middleware can short-circuit so no message is emitted", async () => {
+        ws.use(() => {
+            /* swallow: never calls next() */
+        });
+        const onMessage = vi.fn();
+        ws.on("message", onMessage);
+
+        await connected();
+        server.send(JSON.stringify({ n: 1 }));
+
+        expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it("use() returns the client for chaining", () => {
+        const noop: Middleware = (_c, next) => next();
+        expect(ws.use(noop)).toBe(ws);
+    });
+
+    it("emits error when a middleware throws", async () => {
+        ws.use(() => {
+            throw new Error("boom");
+        });
+        const onError = vi.fn();
+        ws.on("error", onError);
+
+        await connected();
+        server.send(JSON.stringify({ n: 1 }));
+
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it("pingpong replies to ping without emitting it as a message", async () => {
+        ws.use(pingpong);
+        const onMessage = vi.fn();
+        ws.on("message", onMessage);
+
+        await connected();
+        server.send("ping");
+
+        await expect(server).toReceiveMessage("pong");
+        expect(onMessage).not.toHaveBeenCalled();
     });
 
     it("transitions to closed and emits close on close()", async () => {

--- a/packages/durablews/tests/pipeline.test.ts
+++ b/packages/durablews/tests/pipeline.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { runPipeline } from "../src/pipeline";
+import type { MessageContext, Middleware } from "../src/types";
+
+function ctx(data: unknown): MessageContext {
+    return { data, client: {} as never };
+}
+
+describe("runPipeline", () => {
+    it("runs middleware in registration order, then the terminal", () => {
+        const calls: string[] = [];
+        const mws: Middleware[] = [
+            (_c, next) => {
+                calls.push("a");
+                return next();
+            },
+            (_c, next) => {
+                calls.push("b");
+                return next();
+            }
+        ];
+
+        runPipeline(mws, ctx(null), () => calls.push("terminal"));
+
+        expect(calls).toEqual(["a", "b", "terminal"]);
+    });
+
+    it("runs the terminal directly when there is no middleware", () => {
+        const terminal = vi.fn();
+        runPipeline([], ctx(null), terminal);
+        expect(terminal).toHaveBeenCalledTimes(1);
+    });
+
+    it("short-circuits when a middleware does not call next()", () => {
+        const terminal = vi.fn();
+        const second = vi.fn((_c, next) => next());
+        const mws: Middleware[] = [() => {}, second];
+
+        runPipeline(mws, ctx(null), terminal);
+
+        expect(second).not.toHaveBeenCalled();
+        expect(terminal).not.toHaveBeenCalled();
+    });
+
+    it("propagates ctx.data transforms to later stages and the terminal", () => {
+        const mws: Middleware[] = [
+            (c, next) => {
+                c.data = (c.data as number) + 1;
+                return next();
+            }
+        ];
+        const c = ctx(1);
+        let seen: unknown;
+
+        runPipeline(mws, c, () => {
+            seen = c.data;
+        });
+
+        expect(seen).toBe(2);
+    });
+
+    it("throws if next() is called more than once", () => {
+        const mws: Middleware[] = [
+            (_c, next) => {
+                next();
+                return next();
+            }
+        ];
+        expect(() => runPipeline(mws, ctx(null), () => {})).toThrow(
+            /multiple times/
+        );
+    });
+
+    it("returns a promise and awaits async middleware", async () => {
+        const calls: string[] = [];
+        const mws: Middleware[] = [
+            async (_c, next) => {
+                await Promise.resolve();
+                calls.push("a");
+                await next();
+            }
+        ];
+
+        const result = runPipeline(mws, ctx(null), () =>
+            calls.push("terminal")
+        );
+
+        expect(result).toBeInstanceOf(Promise);
+        await result;
+        expect(calls).toEqual(["a", "terminal"]);
+    });
+});

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -371,10 +371,12 @@ travel in-PR):
   console noise removed; `send()` throws when not open. Store, action handlers,
   and pingpong/logger middleware deleted (pipeline returns in slice 3).
   (commit `5c26af7`)
-- 🚧 **Slice 2 — Codec seam.** Pluggable `encode` / `decode` with a default JSON
-  codec; `config.codec` option. Replaces the inline JSON; folds `safeJSONParse`
-  into the default codec; deletes the broken, unused `normalizeURL`.
-- ⬜ **Slice 3 — Middleware pipeline (re-homed).** Standalone pipeline on the
+- ✅ **Slice 2 — Codec seam.** Pluggable `encode` / `decode` with a default JSON
+  codec (`codec.ts` / `jsonCodec`); `config.codec` option. Replaced the inline
+  JSON; folded `safeJSONParse` into the default codec; deleted the broken,
+  unused `normalizeURL` (and the now-empty `utils.ts`). `Codec` + `jsonCodec`
+  exported. (commit `aa71812`)
+- 🚧 **Slice 3 — Middleware pipeline (re-homed).** Standalone pipeline on the
   decoded-message path (not lifecycle). `pingpong` becomes opt-in; the
   default `logger` is dropped. `client.use(...)` retained.
 - ⬜ **Slice 4 — Test pyramid + e2e.** Fill coverage gaps across the core; add a


### PR DESCRIPTION
**M2 slice 3 of 4.** Restores `client.use()` as a standalone onion-model pipeline on the decoded-message path — middleware is no longer coupled to the deleted store or to lifecycle dispatch.

## What changed
- **`pipeline.ts` (`runPipeline`)** — sequential onion model with a terminal step. Short-circuits when a middleware skips `next()`; carries over the old store's "next() called multiple times" guard; supports async middleware.
- **`client.use(middleware)`** registers middleware and returns the client for chaining. Each inbound message flows `decode → pipeline → (terminal) emit "message"`. A middleware that returns without `next()` short-circuits, so the message isn't emitted (e.g. an auto-reply).
- **Errors:** a middleware that throws or rejects surfaces as an `error` event. The `error` payload is widened to `Event | Error` (transport `Event` vs middleware `Error`); `lastError` stays transport-only.
- **`pingpong`** returns as an **opt-in** middleware (`middleware.ts`), no longer wired by default. The old always-on `logger` stays gone.
- Exports `Middleware`, `MessageContext`, `pingpong`.

## Tests
- `pipeline.test.ts` — order, terminal, short-circuit, `ctx.data` transform, double-`next()` guard, async.
- `client.test.ts` — middleware runs / transforms / short-circuits, `use()` chaining, error-on-throw, `pingpong` reply-without-bubbling.
- 56 tests green.

## Docs
`getting-started` lists the middleware pipeline + `pingpong`; RFC slice 2 marked ✅.

With this, the three core seams (FSM, codec, middleware) are in place. **Slice 4** fills the test pyramid and adds Playwright e2e — after which M2 is complete and we move to M3 (durability).