### PR TITLE
ci(docs): wire deploy to production environment + manual dispatch

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,23 +7,29 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/deploy-docs.yml"
+  # Manual trigger for the initial deploy and ad-hoc redeploys.
+  workflow_dispatch:
 
 jobs:
   deploy:
-    # Runs only when a docs PR is *merged* AND deployment has been explicitly
-    # enabled. Set the repo variable DOCS_DEPLOY_ENABLED=true once the
-    # CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID secrets and DNS are in place.
-    if: ${{ github.event.pull_request.merged == true && vars.DOCS_DEPLOY_ENABLED == 'true' }}
+    # Runs only when deployment is explicitly enabled (repo variable
+    # DOCS_DEPLOY_ENABLED=true) AND either a docs PR was merged or it was
+    # dispatched by hand. The `production` environment supplies the Cloudflare
+    # secrets and gates each run behind a required-reviewer approval.
+    if: ${{ vars.DOCS_DEPLOY_ENABLED == 'true' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) }}
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 15
     concurrency:
       group: docs-deploy
       cancel-in-progress: true
     steps:
-      - name: Checkout merge commit
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          # The merge commit for a merged PR; falls back to the triggered ref
+          # (main) for a manual workflow_dispatch.
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Activates the docs deploy now that the Cloudflare secrets are in place.

## Finding
The `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` secrets were added to the **`production` environment**, but the deploy job (a) didn't declare `environment: production`, so it read non-existent *repo-level* secrets, and (b) had no manual trigger. So it could never actually deploy.

## Changes
- **`environment: production`** on the job — resolves the env-scoped secrets, and gates every run behind the environment's required-reviewer approval (`imns`). This makes each go-live an explicit, approved action.
- **`workflow_dispatch`** trigger for the initial deploy and redeploys.
- **`if:`** allows a manual dispatch *or* a merged docs PR, still guarded by `DOCS_DEPLOY_ENABLED == 'true'`.
- **Checkout** falls back to the dispatched ref (`main`) when there's no PR merge commit.

## Remaining to go live (after merge)
1. Set repo variable `DOCS_DEPLOY_ENABLED=true`.
2. Trigger once via `workflow_dispatch` and approve the `production` deployment.

⚠️ **Token-scope caveat:** `wrangler.jsonc` declares `routes: [{ pattern: "durablews.imns.co", custom_domain: true }]`. Provisioning a custom domain needs the API token to have **DNS edit** on the `imns.co` zone, not just *Workers Scripts: Edit*. If the token is Workers-only, the first deploy will fail at the custom-domain step — easy to fix by broadening the token or attaching the domain in the CF dashboard.