### PR TITLE
fix(docs): add .assetsignore so the SSR worker isn't published as a public asset

### DIFF
--- a/docs/public/.assetsignore
+++ b/docs/public/.assetsignore
@@ -1,0 +1,2 @@
+_worker.js
+_routes.json


### PR DESCRIPTION
Fixes the deploy-blocking error hit on a local `wrangler deploy`:

> [ERROR] Uploading a Pages _worker.js directory as an asset. This could expose your private server-side code to the public Internet.

## Cause
The `@astrojs/cloudflare` adapter emits the SSR worker as a **directory** at `dist/_worker.js/`, but `wrangler.jsonc` sets `assets.directory` to `./dist`, which *contains* it. With no ignore file, wrangler would upload the server worker (and the Pages-style `_routes.json`) as public static assets — so it refuses.

## Fix
Add `.assetsignore` listing `_worker.js` + `_routes.json`. Because `dist/` is gitignored and regenerated each build, the file is sourced from **`docs/public/.assetsignore`** so Astro copies it into `dist/` on every build.

## Verified
- `pnpm -F docs build` → `dist/.assetsignore` present alongside `dist/_worker.js/` and `dist/_routes.json`.
- `wrangler deploy --dry-run` → "Read 314 files from the assets directory" with **no `_worker.js` error**.

After this lands, `wrangler deploy` (local or CI) gets past the asset check. The remaining CI hurdle is still the token scope / custom-domain provisioning noted earlier — unblocked by deploying locally first.