### PR TITLE
test(core): integration gaps + Playwright browser e2e (M2 slice 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,22 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build docs site
         run: pnpm -F docs build
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright Chromium
+        run: pnpm -F durablews e2e:install
+      - name: Run browser e2e
+        run: pnpm -F durablews e2e

--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,8 @@ $RECYCLE.BIN/
 
 # Cloudflare / wrangler
 .wrangler/
+
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/

--- a/packages/durablews/e2e/app.html
+++ b/packages/durablews/e2e/app.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>DurableWS e2e</title>
+    </head>
+    <body>
+        <!-- Intentionally empty: the e2e specs drive the built ESM bundle via
+             dynamic import inside page.evaluate(). -->
+    </body>
+</html>

--- a/packages/durablews/e2e/client.e2e.ts
+++ b/packages/durablews/e2e/client.e2e.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+// @ts-expect-error - plain .mjs test helper, no types needed
+import { startEchoServer } from "./echo-server.mjs";
+
+let server: { port: number; close: () => Promise<void> };
+
+test.beforeAll(async () => {
+    server = await startEchoServer();
+});
+
+test.afterAll(async () => {
+    await server.close();
+});
+
+test("connects, round-trips a message, and closes against a real WebSocket", async ({
+    page
+}) => {
+    await page.goto("/e2e/app.html");
+
+    const result = await page.evaluate(async (wsUrl) => {
+        // The built ESM bundle, loaded in a real browser over a real WebSocket.
+        const { defineClient } = await import("/dist/index.js");
+        const ws = defineClient({ url: wsUrl });
+        const messages: unknown[] = [];
+        ws.on("message", (m: unknown) => messages.push(m));
+
+        await ws.connect();
+        const openState = ws.state;
+        ws.send({ hello: "world" });
+
+        await new Promise((r) => setTimeout(r, 200));
+        ws.close();
+        await new Promise((r) => setTimeout(r, 100));
+
+        return { openState, closedState: ws.state, messages };
+    }, `ws://localhost:${server.port}`);
+
+    expect(result.openState).toBe("open");
+    expect(result.messages).toContainEqual({ hello: "world" });
+    expect(result.closedState).toBe("closed");
+});
+
+test("reconnects after closing, against a real WebSocket", async ({ page }) => {
+    await page.goto("/e2e/app.html");
+
+    const result = await page.evaluate(async (wsUrl) => {
+        const { defineClient } = await import("/dist/index.js");
+        const ws = defineClient({ url: wsUrl });
+
+        await ws.connect();
+        ws.close();
+        await new Promise((r) => setTimeout(r, 100));
+        const afterClose = ws.state;
+
+        await ws.connect();
+        const afterReconnect = ws.state;
+
+        const echoed: unknown[] = [];
+        ws.on("message", (m: unknown) => echoed.push(m));
+        ws.send("again");
+        await new Promise((r) => setTimeout(r, 150));
+        ws.close();
+
+        return { afterClose, afterReconnect, echoed };
+    }, `ws://localhost:${server.port}`);
+
+    expect(result.afterClose).toBe("closed");
+    expect(result.afterReconnect).toBe("open");
+    expect(result.echoed).toContain("again");
+});

--- a/packages/durablews/e2e/echo-server.mjs
+++ b/packages/durablews/e2e/echo-server.mjs
@@ -1,0 +1,29 @@
+import { WebSocketServer } from "ws";
+
+/**
+ * Starts a throwaway WebSocket server on a random free port for the browser
+ * e2e tests. It echoes any message back, except a textual "ping" which it
+ * answers with "pong" (so the pingpong middleware can be exercised end-to-end).
+ *
+ * @returns the chosen port and a close() that resolves once the server is down.
+ */
+export function startEchoServer() {
+    return new Promise((resolve) => {
+        const wss = new WebSocketServer({ port: 0 }, () => {
+            const address = wss.address();
+            const port =
+                typeof address === "object" && address ? address.port : 0;
+            resolve({
+                port,
+                close: () => new Promise((done) => wss.close(() => done()))
+            });
+        });
+
+        wss.on("connection", (socket) => {
+            socket.on("message", (data) => {
+                const text = data.toString();
+                socket.send(text === "ping" ? "pong" : text);
+            });
+        });
+    });
+}

--- a/packages/durablews/e2e/static-server.mjs
+++ b/packages/durablews/e2e/static-server.mjs
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { extname, join, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Serve the package root so the browser can `import("/dist/index.js")` (the
+// built ESM bundle) and load `/e2e/app.html`.
+const root = fileURLToPath(new URL("..", import.meta.url));
+const port = Number(process.env.PORT) || 5173;
+
+const CONTENT_TYPES = {
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".html": "text/html",
+    ".json": "application/json",
+    ".map": "application/json",
+    ".css": "text/css"
+};
+
+createServer(async (req, res) => {
+    try {
+        const path = decodeURIComponent((req.url || "/").split("?")[0]);
+        // Block path traversal, then resolve under the package root.
+        const safe = normalize(path).replace(/^(\.\.[/\\])+/, "");
+        const body = await readFile(join(root, safe));
+        res.setHeader(
+            "Content-Type",
+            CONTENT_TYPES[extname(safe)] || "application/octet-stream"
+        );
+        res.end(body);
+    } catch {
+        res.statusCode = 404;
+        res.end("not found");
+    }
+}).listen(port, () => {
+    console.log(`e2e static server on http://localhost:${port}`);
+});

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -28,6 +28,8 @@
         "build": "tsup",
         "test": "vitest",
         "test:run": "vitest run",
+        "e2e": "pnpm run build && playwright test",
+        "e2e:install": "playwright install --with-deps chromium",
         "typecheck": "tsc --noEmit",
         "check:publish": "publint && attw --pack .",
         "prepublishOnly": "pnpm build"
@@ -69,12 +71,15 @@
     ],
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.3",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^20.11.17",
+        "@types/ws": "^8.18.1",
         "jsdom": "^24.0.0",
         "publint": "^0.3.21",
         "tsup": "^8.5.1",
         "typescript": "^5.3.3",
         "vitest": "^1.2.2",
-        "vitest-websocket-mock": "^0.3.0"
+        "vitest-websocket-mock": "^0.3.0",
+        "ws": "^8.21.0"
     }
 }

--- a/packages/durablews/playwright.config.ts
+++ b/packages/durablews/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Real-browser e2e: a static server exposes the built ESM bundle so a real
+// Chromium can drive the client over a real WebSocket (see e2e/echo-server.mjs).
+export default defineConfig({
+    testDir: "./e2e",
+    testMatch: "**/*.e2e.ts",
+    reporter: "list",
+    forbidOnly: !!process.env.CI,
+    use: {
+        baseURL: "http://localhost:5173"
+    },
+    webServer: {
+        command: "node e2e/static-server.mjs",
+        url: "http://localhost:5173/e2e/app.html",
+        reuseExistingServer: !process.env.CI,
+        env: { PORT: "5173" },
+        timeout: 30_000
+    },
+    projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }]
+});

--- a/packages/durablews/tests/client.test.ts
+++ b/packages/durablews/tests/client.test.ts
@@ -233,4 +233,44 @@ describe("client", () => {
         await connected();
         expect(ws.state).toBe("open");
     });
+
+    it("on() returns an unsubscribe that stops delivery", async () => {
+        await connected();
+        const onMessage = vi.fn();
+        const off = ws.on("message", onMessage);
+
+        server.send(JSON.stringify({ n: 1 }));
+        expect(onMessage).toHaveBeenCalledTimes(1);
+
+        off();
+        server.send(JSON.stringify({ n: 2 }));
+        expect(onMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("getState() returns a frozen snapshot", async () => {
+        await connected();
+        const snapshot = ws.getState();
+        expect(Object.isFrozen(snapshot)).toBe(true);
+        expect(snapshot).toEqual({ state: "open", lastError: null });
+    });
+
+    it("emits the full statechange sequence across a connect/close cycle", async () => {
+        const states: string[] = [];
+        ws.on("statechange", ({ current }) => states.push(current));
+
+        await connected();
+        ws.close();
+        await server.closed;
+
+        expect(states).toEqual(["connecting", "open", "closing", "closed"]);
+    });
+
+    it("connect() while closing rejects", async () => {
+        await connected();
+        ws.close();
+        expect(ws.state).toBe("closing");
+
+        await expect(ws.connect()).rejects.toThrow(/closing/);
+        await server.closed;
+    });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,15 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.18.3
         version: 0.18.3
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/node':
         specifier: ^20.11.17
         version: 20.19.42
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3
@@ -63,6 +69,9 @@ importers:
       vitest-websocket-mock:
         specifier: ^0.3.0
         version: 0.3.0(vitest@1.6.1(@types/node@20.19.42)(jsdom@24.1.3))
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
 
 packages:
 
@@ -1413,6 +1422,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -1652,6 +1666,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -2253,6 +2270,11 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3066,6 +3088,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -5037,6 +5069,10 @@ snapshots:
   '@pagefind/windows-x64@1.5.2':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -5220,6 +5256,10 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.42
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -6015,6 +6055,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -7225,6 +7268,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@6.0.1(postcss@8.5.15):
     dependencies:

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -376,11 +376,16 @@ travel in-PR):
   JSON; folded `safeJSONParse` into the default codec; deleted the broken,
   unused `normalizeURL` (and the now-empty `utils.ts`). `Codec` + `jsonCodec`
   exported. (commit `aa71812`)
-- 🚧 **Slice 3 — Middleware pipeline (re-homed).** Standalone pipeline on the
-  decoded-message path (not lifecycle). `pingpong` becomes opt-in; the
-  default `logger` is dropped. `client.use(...)` retained.
-- ⬜ **Slice 4 — Test pyramid + e2e.** Fill coverage gaps across the core; add a
-  Playwright browser e2e harness; wire test tiers into CI.
+- ✅ **Slice 3 — Middleware pipeline (re-homed).** Standalone onion-model
+  pipeline (`pipeline.ts`) on the decoded-message path; `client.use()` returns
+  the client for chaining; short-circuit when a middleware skips `next()`;
+  middleware errors surface as `error` (payload widened to `Event | Error`).
+  `pingpong` is opt-in (`middleware.ts`); the default `logger` is gone.
+  (commit `5a47c0c`)
+- 🚧 **Slice 4 — Test pyramid + e2e.** Fill coverage gaps across the core; add a
+  Playwright browser e2e harness (real Chromium + real `WebSocket` against a
+  local `ws` echo server, exercising the built ESM bundle); wire test tiers into
+  CI.
 
 Order is deliberate: the codec defines what "decoded" means, so it precedes the
 middleware that operates on decoded messages.


### PR DESCRIPTION
**M2 slice 4 of 4 — closes out M2.** Completes the test pyramid.

## Integration (vitest)
Added coverage for gaps in the client:
- `on()` returns an unsubscribe that stops delivery
- `getState()` returns a **frozen** snapshot
- the full `statechange` sequence across a connect/close cycle (`connecting → open → closing → closed`)
- `connect()` rejects while `closing`

## E2E (Playwright, real Chromium)
Drives the **built ESM bundle** (`/dist/index.js`) in a real browser over a **real `WebSocket`** against a throwaway `ws` echo server — the path the jsdom + mock-socket integration layer can't exercise.
- `connects, round-trips a message, and closes` (with `open`/`closed` state assertions)
- `reconnects after closing`

Harness: `e2e/echo-server.mjs` (random-port echo/ping), `e2e/static-server.mjs` (serves the package so the browser can import the bundle), `e2e/app.html`, `playwright.config.ts` (chromium + `webServer`). New devDeps: `@playwright/test`, `ws`, `@types/ws` — all test-only; the library stays zero-dep (`files` is `dist`-only, so none of this is published). Scripts: `e2e` (build + test) and `e2e:install`.

## CI
New **`E2E`** job (installs Chromium, runs the specs). Playwright artifacts gitignored.

⚠️ **Ruleset follow-up:** once `E2E` is green here, I'll add it to the branch ruleset's required checks (the established CI↔ruleset lockstep), then merge — so `E2E` becomes required going forward.

After merge, **M2 (core rewrite) is complete**: FSM + codec + middleware, full pyramid (unit → integration → browser e2e), all green. Next milestone is M3 (durability).