### PR TITLE
fix(codec): pass binary through jsonCodec.encode

### DIFF
--- a/packages/durablews/src/codec.ts
+++ b/packages/durablews/src/codec.ts
@@ -13,15 +13,32 @@ function safeJSONParse(data: string): unknown {
 }
 
 /**
- * The default codec: JSON over text frames.
+ * Whether a value is already a WebSocket-sendable binary frame and should be
+ * passed through rather than JSON-encoded (`ArrayBuffer`, any typed array or
+ * `DataView`, or a `Blob`).
+ */
+function isBinary(
+    data: unknown
+): data is ArrayBufferLike | ArrayBufferView | Blob {
+    return (
+        data instanceof ArrayBuffer ||
+        ArrayBuffer.isView(data) ||
+        (typeof Blob !== "undefined" && data instanceof Blob)
+    );
+}
+
+/**
+ * The default codec: JSON over text frames, binary passed through.
  *
- * - `encode` — strings are sent verbatim; everything else is `JSON.stringify`d.
+ * - `encode` — strings and binary frames (`ArrayBuffer`/typed arrays/`Blob`)
+ *   are sent verbatim; everything else is `JSON.stringify`d.
  * - `decode` — text frames are JSON-parsed (falling back to the raw string);
- *   binary frames (`ArrayBuffer`/`Blob`) are passed through untouched.
+ *   binary frames are passed through untouched.
  */
 export const jsonCodec: Codec = {
     encode(data: unknown) {
-        return typeof data === "string" ? data : JSON.stringify(data);
+        if (typeof data === "string" || isBinary(data)) return data;
+        return JSON.stringify(data);
     },
     decode(data: unknown) {
         return typeof data === "string" ? safeJSONParse(data) : data;

--- a/packages/durablews/tests/codec.test.ts
+++ b/packages/durablews/tests/codec.test.ts
@@ -7,10 +7,22 @@ describe("jsonCodec", () => {
             expect(jsonCodec.encode("hello")).toBe("hello");
         });
 
-        it("JSON-stringifies non-strings", () => {
+        it("JSON-stringifies plain values", () => {
             expect(jsonCodec.encode({ a: 1 })).toBe('{"a":1}');
             expect(jsonCodec.encode([1, 2])).toBe("[1,2]");
             expect(jsonCodec.encode(42)).toBe("42");
+        });
+
+        it("passes binary frames through instead of JSON-encoding them", () => {
+            const buffer = new ArrayBuffer(8);
+            const typed = new Uint8Array([1, 2, 3]);
+            const view = new DataView(new ArrayBuffer(4));
+            const blob = new Blob(["hi"]);
+
+            expect(jsonCodec.encode(buffer)).toBe(buffer);
+            expect(jsonCodec.encode(typed)).toBe(typed);
+            expect(jsonCodec.encode(view)).toBe(view);
+            expect(jsonCodec.encode(blob)).toBe(blob);
         });
     });
 


### PR DESCRIPTION
Closes a correctness hole in the M2 codec seam.

## Bug
`jsonCodec.encode` was `typeof data === "string" ? data : JSON.stringify(data)`. So any binary payload — `ArrayBuffer`, a typed array, `DataView`, or `Blob` — was `JSON.stringify`'d into `"{}"` and sent as that string. The default codec silently corrupted **every** binary send.

## Fix
`encode` now passes native WebSocket-sendable binary types through untouched (`ArrayBuffer`, `ArrayBuffer.isView(...)` for typed arrays + `DataView`, and `Blob` when defined), and only `JSON.stringify`s plain values. `decode` already passed binary through.

Tests cover each binary type plus the existing string/JSON paths. 61 tests green.