### PR TITLE
chore: add .editorconfig; commit editor formatting of wrangler.jsonc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# YAML requires 2-space indentation.
+[*.{yml,yaml}]
+indent_size = 2
+
+# Trailing whitespace can be a hard line break in Markdown.
+[*.md]
+trim_trailing_whitespace = false

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -7,11 +7,11 @@
     "compatibility_flags": ["nodejs_compat"],
     "assets": {
         "binding": "ASSETS",
-        "directory": "./dist"
+        "directory": "./dist",
     },
     "observability": {
-        "enabled": true
+        "enabled": true,
     },
     "keep_vars": true,
-    "routes": [{ "pattern": "durablews.imns.co", "custom_domain": true }]
+    "routes": [{ "pattern": "durablews.imns.co", "custom_domain": true }],
 }


### PR DESCRIPTION
Adds a root `.editorconfig` aligned with the Biome config (utf-8, LF, 4-space, final newline, trim trailing whitespace) with YAML→2-space and Markdown→keep-trailing-whitespace overrides. Codifies conventions for editors and would have caught the earlier stray reindents / missing final newline.

Also commits the trailing-comma formatting an editor applied to `docs/wrangler.jsonc` (valid JSONC; `docs/` is outside Biome's scope).

Note: `.editorconfig` has no trailing-comma setting — code stays governed by Biome (stripped at the pre-commit hook), `docs/` by the editor.