### PR TITLE
chore: curly braces, TS6-proof codec type, advisory typecheck:next, editor on Biome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,28 @@ jobs:
       - name: tsc --noEmit
         run: pnpm -F durablews typecheck
 
+  # Advisory: type-checks against typescript@next so upcoming-TS breakage
+  # (e.g. TS 6's stricter WebSocket.send) is visible early. Deliberately NOT in
+  # the branch ruleset's required checks — a nightly compiler must not gate
+  # merges. continue-on-error keeps the workflow run green if it fails.
+  typecheck-next:
+    name: Typecheck (next, advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: tsc --noEmit (typescript@next)
+        run: pnpm -F durablews typecheck:next
+
   test:
     name: Test (Node ${{ matrix.node }})
     runs-on: ubuntu-latest

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.codeActionsOnSave": {
+        "source.organizeImports.biome": "explicit"
+    },
+    "[javascript]": { "editor.defaultFormatter": "biomejs.biome" },
+    "[typescript]": { "editor.defaultFormatter": "biomejs.biome" },
+    "[json]": { "editor.defaultFormatter": "biomejs.biome" },
+    "[jsonc]": { "editor.defaultFormatter": "biomejs.biome" }
+}

--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,10 @@
     "linter": {
         "enabled": true,
         "rules": {
-            "recommended": true
+            "recommended": true,
+            "style": {
+                "useBlockStatements": "error"
+            }
         }
     },
     "javascript": {

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -72,7 +72,7 @@
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.3",
         "@playwright/test": "^1.60.0",
-        "@types/node": "^20.11.17",
+        "@types/node": "^22.19.20",
         "@types/ws": "^8.18.1",
         "jsdom": "^24.0.0",
         "publint": "^0.3.21",

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -31,6 +31,7 @@
         "e2e": "pnpm run build && playwright test",
         "e2e:install": "playwright install --with-deps chromium",
         "typecheck": "tsc --noEmit",
+        "typecheck:next": "pnpm --package=typescript@next dlx tsc --noEmit",
         "check:publish": "publint && attw --pack .",
         "prepublishOnly": "pnpm build"
     },

--- a/packages/durablews/src/client.ts
+++ b/packages/durablews/src/client.ts
@@ -55,7 +55,9 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
      */
     function transition(event: ConnectionEvent): ConnectionState | null {
         const next = nextState(state, event);
-        if (next === null || next === state) return null;
+        if (next === null || next === state) {
+            return null;
+        }
 
         const previous = state;
         state = next;
@@ -141,8 +143,12 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         },
 
         connect() {
-            if (state === "open") return Promise.resolve();
-            if (state === "connecting" && pending) return pending.promise;
+            if (state === "open") {
+                return Promise.resolve();
+            }
+            if (state === "connecting" && pending) {
+                return pending.promise;
+            }
             if (state === "closing") {
                 return Promise.reject(
                     new Error(
@@ -189,7 +195,9 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         },
 
         close(code?: number, reason?: string) {
-            if (!socket) return;
+            if (!socket) {
+                return;
+            }
             transition("CLOSE_REQUESTED");
             socket.close(code, reason);
         },

--- a/packages/durablews/src/codec.ts
+++ b/packages/durablews/src/codec.ts
@@ -16,8 +16,12 @@ function safeJSONParse(data: string): unknown {
  * Whether a value is already a WebSocket-sendable binary frame and should be
  * passed through rather than JSON-encoded (`ArrayBuffer`, any typed array or
  * `DataView`, or a `Blob`).
+ *
+ * The predicate claims `BufferSource` (what `WebSocket.send` accepts), which
+ * asserts the view is not backed by a `SharedArrayBuffer` — `send` rejects
+ * those at runtime, so they were never sendable anyway.
  */
-function isBinary(data: unknown): data is ArrayBuffer | ArrayBufferView | Blob {
+function isBinary(data: unknown): data is BufferSource | Blob {
     return (
         data instanceof ArrayBuffer ||
         ArrayBuffer.isView(data) ||

--- a/packages/durablews/src/codec.ts
+++ b/packages/durablews/src/codec.ts
@@ -37,7 +37,9 @@ function isBinary(
  */
 export const jsonCodec: Codec = {
     encode(data: unknown) {
-        if (typeof data === "string" || isBinary(data)) return data;
+        if (typeof data === "string" || isBinary(data)) {
+            return data;
+        }
         return JSON.stringify(data);
     },
     decode(data: unknown) {

--- a/packages/durablews/src/codec.ts
+++ b/packages/durablews/src/codec.ts
@@ -17,9 +17,7 @@ function safeJSONParse(data: string): unknown {
  * passed through rather than JSON-encoded (`ArrayBuffer`, any typed array or
  * `DataView`, or a `Blob`).
  */
-function isBinary(
-    data: unknown
-): data is ArrayBufferLike | ArrayBufferView | Blob {
+function isBinary(data: unknown): data is ArrayBuffer | ArrayBufferView | Blob {
     return (
         data instanceof ArrayBuffer ||
         ArrayBuffer.isView(data) ||

--- a/packages/durablews/src/helpers/event-bus.ts
+++ b/packages/durablews/src/helpers/event-bus.ts
@@ -55,7 +55,9 @@ export function defineEventBus(): EventBus {
         handler: (payload: T) => void
     ) {
         const handlers = listeners.get(eventName);
-        if (!handlers) return;
+        if (!handlers) {
+            return;
+        }
         listeners.set(
             eventName,
             handlers.filter((h) => h !== handler)

--- a/packages/durablews/src/pipeline.ts
+++ b/packages/durablews/src/pipeline.ts
@@ -27,7 +27,9 @@ export function runPipeline(
         invoked = i;
 
         const middleware = middlewares[i];
-        if (!middleware) return terminal();
+        if (!middleware) {
+            return terminal();
+        }
         return middleware(ctx, () => dispatch(i + 1));
     }
 

--- a/packages/durablews/src/types.ts
+++ b/packages/durablews/src/types.ts
@@ -8,7 +8,7 @@
  */
 export interface Codec {
     /** Encode an outgoing value into a WebSocket-sendable frame. */
-    encode(data: unknown): string | ArrayBufferLike | Blob | ArrayBufferView;
+    encode(data: unknown): string | ArrayBuffer | Blob | ArrayBufferView;
     /** Decode an incoming frame (`string` for text, `ArrayBuffer`/`Blob` for binary). */
     decode(data: unknown): unknown;
 }

--- a/packages/durablews/src/types.ts
+++ b/packages/durablews/src/types.ts
@@ -7,8 +7,15 @@
  * for binary protocols, schema-based formats, etc.
  */
 export interface Codec {
-    /** Encode an outgoing value into a WebSocket-sendable frame. */
-    encode(data: unknown): string | ArrayBuffer | Blob | ArrayBufferView;
+    /**
+     * Encode an outgoing value into a WebSocket-sendable frame.
+     *
+     * The return type deliberately mirrors `WebSocket.send`'s parameter
+     * (`BufferSource` is its exact alias), so the codec contract can never
+     * drift looser than what the socket accepts — e.g. TS 6's lib excludes
+     * `SharedArrayBuffer`-backed views from `send`, and this excludes them too.
+     */
+    encode(data: unknown): string | BufferSource | Blob;
     /** Decode an incoming frame (`string` for text, `ArrayBuffer`/`Blob` for binary). */
     decode(data: unknown): unknown;
 }

--- a/packages/durablews/tsconfig.json
+++ b/packages/durablews/tsconfig.json
@@ -22,6 +22,6 @@
         "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true
     },
-    "include": ["src"],
+    "include": ["src", "tests"],
     "exclude": ["node_modules", "dist"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
       '@types/node':
-        specifier: ^20.11.17
-        version: 20.19.42
+        specifier: ^22.19.20
+        version: 22.19.20
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -65,10 +65,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.2.2
-        version: 1.6.1(@types/node@20.19.42)(jsdom@24.1.3)
+        version: 1.6.1(@types/node@22.19.20)(jsdom@24.1.3)
       vitest-websocket-mock:
         specifier: ^0.3.0
-        version: 0.3.0(vitest@1.6.1(@types/node@20.19.42)(jsdom@24.1.3))
+        version: 0.3.0(vitest@1.6.1(@types/node@22.19.20)(jsdom@24.1.3))
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -1654,6 +1654,9 @@ packages:
 
   '@types/node@20.19.42':
     resolution: {integrity: sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==}
+
+  '@types/node@22.19.20':
+    resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
 
   '@types/node@24.13.1':
     resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
@@ -5245,6 +5248,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.19.20':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@24.13.1':
     dependencies:
       undici-types: 7.18.2
@@ -7950,13 +7957,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@1.6.1(@types/node@20.19.42):
+  vite-node@1.6.1(@types/node@22.19.20):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.21(@types/node@20.19.42)
+      vite: 5.4.21(@types/node@22.19.20)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7968,13 +7975,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21(@types/node@20.19.42):
+  vite@5.4.21(@types/node@22.19.20):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.15
       rollup: 4.61.1
     optionalDependencies:
-      '@types/node': 20.19.42
+      '@types/node': 22.19.20
       fsevents: 2.3.3
 
   vite@6.4.3(@types/node@24.13.1):
@@ -7993,13 +8000,13 @@ snapshots:
     optionalDependencies:
       vite: 6.4.3(@types/node@24.13.1)
 
-  vitest-websocket-mock@0.3.0(vitest@1.6.1(@types/node@20.19.42)(jsdom@24.1.3)):
+  vitest-websocket-mock@0.3.0(vitest@1.6.1(@types/node@22.19.20)(jsdom@24.1.3)):
     dependencies:
       jest-diff: 29.7.0
       mock-socket: 9.3.1
-      vitest: 1.6.1(@types/node@20.19.42)(jsdom@24.1.3)
+      vitest: 1.6.1(@types/node@22.19.20)(jsdom@24.1.3)
 
-  vitest@1.6.1(@types/node@20.19.42)(jsdom@24.1.3):
+  vitest@1.6.1(@types/node@22.19.20)(jsdom@24.1.3):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -8018,11 +8025,11 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.21(@types/node@20.19.42)
-      vite-node: 1.6.1(@types/node@20.19.42)
+      vite: 5.4.21(@types/node@22.19.20)
+      vite-node: 1.6.1(@types/node@22.19.20)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.42
+      '@types/node': 22.19.20
       jsdom: 24.1.3
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Tooling + correctness fixes, completing the type-error thread.

## 1. Require curly braces
Biome `useBlockStatements` enabled; autofixed across the core.

## 2. Codec type hole — fixed properly this time
The first attempt narrowed `ArrayBufferLike → ArrayBuffer` but missed that a bare `ArrayBufferView` is `ArrayBufferView<ArrayBufferLike>` — still rejected by TS 6's stricter `WebSocket.send`. **`Codec.encode` now returns `string | BufferSource | Blob`** — `BufferSource` is the exact alias of `send`'s own parameter, so the codec contract tightens in lockstep with the lib and can never drift looser than the socket accepts.

## 3. Advisory `typecheck:next` (the "make our tools catch it" ask)
Stable `tsc` *cannot* see this class of error — only TS 6 nightlies can. New `typecheck:next` script (runs `tsc` from `typescript@next` via pnpm dlx) + **`Typecheck (next, advisory)`** CI job: `continue-on-error`, deliberately **not** a required check (a nightly compiler must not gate merges). Proven **red** on the old typing, **green** on the fix.

## 4. Hardened checks + editor alignment
- Typecheck now covers `tests/` (was `src/` only); `@types/node` ^20 → ^22.
- `.vscode/settings.json` makes Biome the format-on-save default (+ extension recommendation) — ends the Prettier-vs-Biome trailing-comma drift (`.editorconfig` can't govern commas).

All 8 checks green, including the advisory job on today's nightly.