### PR TITLE
feat(core): automatic reconnection with full-jitter backoff (M3 slice 1)

### DIFF
--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -46,18 +46,31 @@ client.close();
 
 ## What works today
 
+- **Automatic reconnection, on by default** — full-jitter exponential backoff
+  with unlimited retries. An unexpected disconnect transparently recovers; a
+  `reconnecting` event (`{ attempt, delay }`) keeps your UI informed. Tune or
+  disable via the `reconnect` option (`baseDelay`, `factor`, `maxDelay`,
+  `jitter`, `maxRetries`, `shouldReconnect`, or `reconnect: false`).
 - Connect / send / close over the standard `WebSocket`, driven by an explicit
   connection state machine
 - Incoming-message handling and lifecycle events (`open`, `message`, `close`,
-  `error`, `statechange`) via `on()`
-- A read-only `state` and `getState()` snapshot
+  `error`, `statechange`, `reconnecting`) via `on()`
+- A read-only `state` and `getState()` snapshot (incl. `retryAttempt`)
 - A pluggable wire-format codec (`codec` option; JSON by default)
 - A message middleware pipeline (`use()`), with an opt-in `pingpong` keepalive
 
+:::note[`connect()` and unlimited retries]
+`connect()` resolves on the first successful open — including when that open is
+a successful retry. Under the default `maxRetries: Infinity` it never rejects:
+against a down host it stays pending while the client keeps trying. That is the
+durable-by-default contract. Need a deadline? Set a finite `maxRetries` or race
+it: `Promise.race([client.connect(), timeout(10_000)])`.
+:::
+
 ## On the roadmap
 
-Automatic reconnection with exponential backoff, message queueing while
-disconnected, idle detection, and channels. Until these land, treat the
-durability features as a roadmap rather than a guarantee — see the
+Message queueing while disconnected, idle detection (opt-in heartbeat), and
+channels. Until these land, treat them as a roadmap rather than a guarantee —
+see the
 [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
 for the full plan and status.

--- a/packages/durablews/e2e/client.e2e.ts
+++ b/packages/durablews/e2e/client.e2e.ts
@@ -68,3 +68,46 @@ test("reconnects after closing, against a real WebSocket", async ({ page }) => {
     expect(result.afterReconnect).toBe("open");
     expect(result.echoed).toContain("again");
 });
+
+test("transparently reconnects when the server drops the connection", async ({
+    page
+}) => {
+    await page.goto("/e2e/app.html");
+
+    const result = await page.evaluate(async (wsUrl) => {
+        const { defineClient } = await import("/dist/index.js");
+        const ws = defineClient({
+            url: wsUrl,
+            reconnect: { baseDelay: 50, jitter: false }
+        });
+        const states: string[] = [];
+        ws.on("statechange", ({ current }: { current: string }) =>
+            states.push(current)
+        );
+        const retries: number[] = [];
+        ws.on("reconnecting", ({ attempt }: { attempt: number }) =>
+            retries.push(attempt)
+        );
+
+        await ws.connect();
+        ws.send("drop"); // the server closes this connection (code 1012)
+
+        // Wait for the drop + automatic reconnect to play out.
+        await new Promise((r) => setTimeout(r, 600));
+        const recovered = ws.state;
+
+        // Prove the recovered connection actually works.
+        const echoed: unknown[] = [];
+        ws.on("message", (m: unknown) => echoed.push(m));
+        ws.send("after-reconnect");
+        await new Promise((r) => setTimeout(r, 200));
+        ws.close();
+
+        return { states, retries, recovered, echoed };
+    }, `ws://localhost:${server.port}`);
+
+    expect(result.states).toContain("reconnecting");
+    expect(result.retries).toContain(1);
+    expect(result.recovered).toBe("open");
+    expect(result.echoed).toContain("after-reconnect");
+});

--- a/packages/durablews/e2e/echo-server.mjs
+++ b/packages/durablews/e2e/echo-server.mjs
@@ -2,8 +2,10 @@ import { WebSocketServer } from "ws";
 
 /**
  * Starts a throwaway WebSocket server on a random free port for the browser
- * e2e tests. It echoes any message back, except a textual "ping" which it
- * answers with "pong" (so the pingpong middleware can be exercised end-to-end).
+ * e2e tests. It echoes any message back, with two special textual commands:
+ * "ping" is answered with "pong" (pingpong middleware), and "drop" makes the
+ * server close that connection — the server stays up, so a reconnecting
+ * client can come back (reconnection e2e).
  *
  * @returns the chosen port and a close() that resolves once the server is down.
  */
@@ -22,6 +24,10 @@ export function startEchoServer() {
         wss.on("connection", (socket) => {
             socket.on("message", (data) => {
                 const text = data.toString();
+                if (text === "drop") {
+                    socket.close(1012, "server drop");
+                    return;
+                }
                 socket.send(text === "ping" ? "pong" : text);
             });
         });

--- a/packages/durablews/src/backoff.ts
+++ b/packages/durablews/src/backoff.ts
@@ -1,0 +1,54 @@
+import type { ReconnectOptions } from "@/types";
+
+/** `ReconnectOptions` with every field filled in. */
+export type ResolvedReconnect = Required<ReconnectOptions>;
+
+/**
+ * The durable-by-default reconnection policy: full-jitter exponential backoff,
+ * never give up. See the RFC's M3 decisions for the rationale behind each value.
+ */
+export const RECONNECT_DEFAULTS: ResolvedReconnect = {
+    baseDelay: 500,
+    factor: 2,
+    maxDelay: 30_000,
+    jitter: true,
+    maxRetries: Number.POSITIVE_INFINITY,
+    shouldReconnect: () => true
+};
+
+/**
+ * Resolve the user's `reconnect` config: `false` disables reconnection
+ * entirely (`null`), anything else is merged over the defaults.
+ */
+export function resolveReconnect(
+    option: false | ReconnectOptions | undefined
+): ResolvedReconnect | null {
+    if (option === false) {
+        return null;
+    }
+    return { ...RECONNECT_DEFAULTS, ...option };
+}
+
+/**
+ * Compute the backoff delay for a retry.
+ *
+ * The exponential delay is `baseDelay × factorᵃᵗᵗᵉᵐᵖᵗ`, capped at `maxDelay`.
+ * With jitter (the default), the actual delay is drawn uniformly from
+ * `[0, exponential]` — "full jitter", which spreads a fleet of simultaneously
+ * dropped clients across the whole window instead of letting them retry in
+ * synchronized waves.
+ *
+ * @param attempt - 0-based: the first retry is attempt `0`.
+ * @param random - injectable for deterministic tests; defaults to `Math.random`.
+ */
+export function computeDelay(
+    attempt: number,
+    options: ResolvedReconnect,
+    random: () => number = Math.random
+): number {
+    const exponential = Math.min(
+        options.maxDelay,
+        options.baseDelay * options.factor ** attempt
+    );
+    return options.jitter ? random() * exponential : exponential;
+}

--- a/packages/durablews/src/client.ts
+++ b/packages/durablews/src/client.ts
@@ -1,3 +1,4 @@
+import { computeDelay, resolveReconnect } from "@/backoff";
 import { jsonCodec } from "@/codec";
 import { nextState } from "@/fsm";
 import { defineEventBus } from "@/helpers/event-bus";
@@ -15,6 +16,10 @@ import type {
 /**
  * Creates a WebSocket client driven by an explicit connection FSM.
  *
+ * Durable by default: an unexpected disconnect schedules a reconnect with
+ * full-jitter exponential backoff (see `backoff.ts`); pass `reconnect: false`
+ * to opt out.
+ *
  * @param config - Connection configuration (at minimum, a `url`).
  *
  * @example
@@ -22,6 +27,9 @@ import type {
  * const ws = client({ url: "wss://example.com/socket" });
  *
  * ws.on("message", (data) => console.log("received:", data));
+ * ws.on("reconnecting", ({ attempt, delay }) => {
+ *     console.log(`retry #${attempt} in ${Math.round(delay)}ms`);
+ * });
  *
  * await ws.connect();
  * ws.send({ type: "hello", message: "world" });
@@ -32,15 +40,24 @@ import type {
 export function client(config: WebSocketClientConfig): WebSocketClient {
     const bus = defineEventBus();
     const codec = config.codec ?? jsonCodec;
+    const reconnect = resolveReconnect(config.reconnect);
     const middlewares: Middleware[] = [];
 
     let socket: WebSocket | null = null;
     let state: ConnectionState = "idle";
     let lastError: Event | null = null;
 
+    // True between a user close() and the next connect(); suppresses
+    // reconnection so "the user hung up" is never retried.
+    let closeRequested = false;
+    // Retries used in the current disconnection episode (see ClientState).
+    let retryAttempt = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
     // The in-flight connect() promise and its settlers. A single promise is
     // shared across concurrent/repeat connect() calls so the method is
-    // idempotent; it is cleared once the connection opens or terminally fails.
+    // idempotent, and it survives failed attempts while reconnection is
+    // active — it settles only on first open or terminal failure.
     let pending: {
         readonly promise: Promise<void>;
         readonly resolve: () => void;
@@ -75,6 +92,26 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         pending = null;
     }
 
+    function clearRetryTimer() {
+        if (retryTimer !== null) {
+            clearTimeout(retryTimer);
+            retryTimer = null;
+        }
+    }
+
+    /**
+     * Whether an unexpected close should be retried: reconnection enabled, not
+     * a user `close()`, retries left, and no `shouldReconnect` veto.
+     */
+    function isRetryable(event: CloseEvent): boolean {
+        return (
+            reconnect !== null &&
+            !closeRequested &&
+            retryAttempt < reconnect.maxRetries &&
+            reconnect.shouldReconnect(event)
+        );
+    }
+
     function openSocket() {
         lastError = null;
         socket = config.protocols
@@ -82,6 +119,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
             : new WebSocket(config.url);
 
         socket.onopen = () => {
+            retryAttempt = 0;
             transition("OPEN");
             bus.emit("open");
             settleConnected();
@@ -98,17 +136,38 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
 
         socket.onclose = (event: CloseEvent) => {
             const wasConnecting = state === "connecting";
-            transition("CLOSED");
             socket = null;
+
+            if (reconnect !== null && isRetryable(event)) {
+                // Event order is deliberate: statechange (state already moved
+                // to `reconnecting`), then the close that caused it, then the
+                // retry announcement with attempt + delay.
+                retryAttempt += 1;
+                const delay = computeDelay(retryAttempt - 1, reconnect);
+                transition("RETRY");
+                bus.emit("close", event);
+                bus.emit("reconnecting", { attempt: retryAttempt, delay });
+                retryTimer = setTimeout(() => {
+                    retryTimer = null;
+                    if (transition("CONNECT") !== null) {
+                        openSocket();
+                    }
+                }, delay);
+                return; // pending connect() survives the retry
+            }
+
+            transition("CLOSED");
             bus.emit("close", event);
-            // A socket that closes before it ever opened is a terminal failure
-            // for this connect() call (reconnection lands in M3).
-            if (wasConnecting) {
+            // Terminal for any in-flight connect(): closed before first open
+            // with no (further) retries coming.
+            if (wasConnecting || pending) {
                 settleFailed(
                     new Error(
-                        `WebSocket closed before opening (code ${event.code}${
-                            event.reason ? `: ${event.reason}` : ""
-                        })`
+                        retryAttempt > 0
+                            ? `WebSocket reconnect gave up after ${retryAttempt} attempt(s) (code ${event.code})`
+                            : `WebSocket closed before opening (code ${event.code}${
+                                  event.reason ? `: ${event.reason}` : ""
+                              })`
                     )
                 );
             }
@@ -137,6 +196,21 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         }
     }
 
+    /** Lazily create (or reuse) the shared connect() promise. */
+    function ensurePending(): Promise<void> {
+        if (pending) {
+            return pending.promise;
+        }
+        let resolve!: () => void;
+        let reject!: (reason: Error) => void;
+        const promise = new Promise<void>((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        pending = { promise, resolve, reject };
+        return promise;
+    }
+
     const api: WebSocketClient = {
         get state() {
             return state;
@@ -146,8 +220,8 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
             if (state === "open") {
                 return Promise.resolve();
             }
-            if (state === "connecting" && pending) {
-                return pending.promise;
+            if (state === "connecting") {
+                return ensurePending();
             }
             if (state === "closing") {
                 return Promise.reject(
@@ -156,30 +230,31 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
                     )
                 );
             }
+            if (state === "reconnecting") {
+                // Skip the rest of the backoff wait and attempt now.
+                clearRetryTimer();
+                const promise = ensurePending();
+                transition("CONNECT");
+                openSocket();
+                return promise;
+            }
 
-            // idle or closed → start a fresh attempt.
+            // idle or closed → start a fresh episode.
+            closeRequested = false;
+            retryAttempt = 0;
             if (transition("CONNECT") === null) {
                 return Promise.reject(
                     new Error(`Cannot connect() from state "${state}"`)
                 );
             }
 
-            let resolve!: () => void;
-            let reject!: (reason: Error) => void;
-            const promise = new Promise<void>((res, rej) => {
-                resolve = res;
-                reject = rej;
-            });
-            pending = { promise, resolve, reject };
-
+            const promise = ensurePending();
             try {
                 openSocket();
             } catch (error) {
                 transition("CLOSED");
                 socket = null;
-                const reason =
-                    error instanceof Error ? error : new Error(String(error));
-                settleFailed(reason);
+                settleFailed(toError(error));
             }
 
             return promise;
@@ -195,6 +270,19 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         },
 
         close(code?: number, reason?: string) {
+            closeRequested = true;
+            clearRetryTimer();
+            retryAttempt = 0;
+
+            if (state === "reconnecting") {
+                // No socket exists while waiting out the backoff: go straight
+                // to closed and terminate any in-flight connect().
+                transition("CLOSE_REQUESTED");
+                settleFailed(
+                    new Error("close() called before the connection opened")
+                );
+                return;
+            }
             if (!socket) {
                 return;
             }
@@ -216,7 +304,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         },
 
         getState(): ClientState {
-            return Object.freeze({ state, lastError });
+            return Object.freeze({ state, lastError, retryAttempt });
         }
     };
 

--- a/packages/durablews/src/fsm.ts
+++ b/packages/durablews/src/fsm.ts
@@ -22,13 +22,22 @@ const TRANSITIONS: Record<
     connecting: {
         OPEN: "open",
         CLOSE_REQUESTED: "closing",
-        CLOSED: "closed"
+        CLOSED: "closed",
+        RETRY: "reconnecting"
     },
     open: {
         CLOSE_REQUESTED: "closing",
-        CLOSED: "closed"
+        CLOSED: "closed",
+        RETRY: "reconnecting"
     },
     closing: { CLOSED: "closed" },
+    // `reconnecting` = waiting out the backoff delay; no socket exists, so
+    // CLOSE_REQUESTED goes straight to `closed` (there is nothing to wait for)
+    // and OPEN/CLOSED cannot legally occur.
+    reconnecting: {
+        CONNECT: "connecting",
+        CLOSE_REQUESTED: "closed"
+    },
     closed: { CONNECT: "connecting" }
 };
 

--- a/packages/durablews/src/index.ts
+++ b/packages/durablews/src/index.ts
@@ -16,6 +16,7 @@ export function defineClient(config: WebSocketClientConfig): WebSocketClient {
     return client(config);
 }
 
+export { RECONNECT_DEFAULTS } from "@/backoff";
 export { jsonCodec } from "@/codec";
 export { pingpong } from "@/middleware";
 export type {
@@ -25,6 +26,8 @@ export type {
     ConnectionState,
     MessageContext,
     Middleware,
+    ReconnectingEvent,
+    ReconnectOptions,
     StateChange,
     WebSocketClient,
     WebSocketClientConfig

--- a/packages/durablews/src/types.ts
+++ b/packages/durablews/src/types.ts
@@ -21,6 +21,33 @@ export interface Codec {
 }
 
 /**
+ * Tuning for automatic reconnection. All fields optional — the defaults give
+ * full-jitter exponential backoff with unlimited retries.
+ */
+export interface ReconnectOptions {
+    /** First-retry delay ceiling in ms. Default `500`. */
+    readonly baseDelay?: number;
+    /** Exponential growth factor. Default `2`. */
+    readonly factor?: number;
+    /** Delay ceiling in ms. Default `30_000`. */
+    readonly maxDelay?: number;
+    /**
+     * Full jitter: each delay is drawn uniformly from `[0, computed]`, so a
+     * fleet of clients dropped at once doesn't retry in synchronized waves.
+     * Default `true`; set `false` for exact exponential delays.
+     */
+    readonly jitter?: boolean;
+    /** Retries per disconnection before giving up. Default `Infinity`. */
+    readonly maxRetries?: number;
+    /**
+     * Decide per-close whether to reconnect (e.g. skip auth rejections by
+     * close code). Default: always reconnect. User-initiated `close()` never
+     * reconnects, regardless of this.
+     */
+    readonly shouldReconnect?: (event: CloseEvent) => boolean;
+}
+
+/**
  * Configuration options for the WebSocket client.
  */
 export interface WebSocketClientConfig {
@@ -30,6 +57,11 @@ export interface WebSocketClientConfig {
     readonly protocols?: string | string[];
     /** Wire-format codec. Defaults to JSON (`jsonCodec`). */
     readonly codec?: Codec;
+    /**
+     * Automatic reconnection — **on by default** (durable by default). Pass
+     * `false` to disable, or options to tune the backoff.
+     */
+    readonly reconnect?: false | ReconnectOptions;
 }
 
 /**
@@ -39,25 +71,32 @@ export interface WebSocketClientConfig {
  * - `connecting` — a socket is open-in-progress, awaiting the first `open`.
  * - `open` — connected and ready to send/receive.
  * - `closing` — a close has been requested, awaiting the socket to finish.
+ * - `reconnecting` — the connection dropped; waiting out the backoff delay
+ *   before the next attempt.
  * - `closed` — the socket is closed; the client may `connect()` again.
- *
- * (Reconnection introduces a `reconnecting` state in M3.)
  */
 export type ConnectionState =
     | "idle"
     | "connecting"
     | "open"
     | "closing"
+    | "reconnecting"
     | "closed";
 
 /**
  * The internal events that drive the connection FSM.
  *
  * `OPEN` / `CLOSED` originate from the underlying socket; `CONNECT` /
- * `CLOSE_REQUESTED` originate from the user calling `connect()` / `close()`.
- * Transport errors are handled out-of-band and are not FSM events — see `fsm.ts`.
+ * `CLOSE_REQUESTED` originate from the user calling `connect()` / `close()`;
+ * `RETRY` is fired when a reconnect attempt is scheduled. Transport errors are
+ * handled out-of-band and are not FSM events — see `fsm.ts`.
  */
-export type ConnectionEvent = "CONNECT" | "OPEN" | "CLOSE_REQUESTED" | "CLOSED";
+export type ConnectionEvent =
+    | "CONNECT"
+    | "OPEN"
+    | "CLOSE_REQUESTED"
+    | "CLOSED"
+    | "RETRY";
 
 /**
  * A read-only snapshot of the client's observable state. Bounded by design —
@@ -68,6 +107,21 @@ export interface ClientState {
     readonly state: ConnectionState;
     /** The most recent transport error, if any. */
     readonly lastError: Event | null;
+    /**
+     * Retries used in the current disconnection episode. `0` while healthy;
+     * resets on a successful open or a user `close()`.
+     */
+    readonly retryAttempt: number;
+}
+
+/**
+ * Payload emitted on every `reconnecting` event (one per scheduled retry).
+ */
+export interface ReconnectingEvent {
+    /** 1-based retry number within this disconnection episode. */
+    readonly attempt: number;
+    /** The backoff delay (ms) before this attempt fires. */
+    readonly delay: number;
 }
 
 /**
@@ -124,6 +178,8 @@ export interface ClientEventMap {
     error: Event | Error;
     /** The connection state changed. */
     statechange: StateChange;
+    /** A reconnect attempt was scheduled (fires once per retry). */
+    reconnecting: ReconnectingEvent;
 }
 
 /**
@@ -136,14 +192,26 @@ export interface WebSocketClient {
     /**
      * Opens the connection.
      *
-     * Resolves the first time the socket opens. Calling it while already
-     * `open` resolves immediately; calling it while `connecting` returns the
-     * same in-flight promise (idempotent). Rejects only on a terminal failure —
-     * in this release, a connection that closes before it ever opens.
+     * Resolves the first time the socket opens — including when that open is
+     * a successful *retry* (the promise survives failed attempts while
+     * reconnection is active). Calling it while already `open` resolves
+     * immediately; calling it while `connecting` returns the same in-flight
+     * promise (idempotent); calling it while `reconnecting` skips the backoff
+     * wait and attempts immediately.
      *
-     * Failures *after* the first open surface via the `error` / `close` events,
-     * not this promise. For fire-and-forget use, attach a `.catch` or listen
-     * for `error` to avoid an unhandled rejection.
+     * Rejects only on **terminal** failure: retries exhausted
+     * (`reconnect.maxRetries`), a `shouldReconnect` veto, `close()` before the
+     * first open, or — with `reconnect: false` — any close before opening.
+     *
+     * **Under the default `maxRetries: Infinity`, this promise never rejects**:
+     * against a down host it stays pending while the client keeps retrying.
+     * That is the durable-by-default contract, by design. If you need a
+     * deadline, set a finite `maxRetries` or race it:
+     * `Promise.race([client.connect(), timeout(10_000)])`.
+     *
+     * Failures *after* the first open surface via the `error` / `close` /
+     * `reconnecting` events, not this promise. For fire-and-forget use, attach
+     * a `.catch` or listen for `error` to avoid an unhandled rejection.
      */
     connect(): Promise<void>;
 

--- a/packages/durablews/tests/backoff.test.ts
+++ b/packages/durablews/tests/backoff.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+    computeDelay,
+    RECONNECT_DEFAULTS,
+    resolveReconnect
+} from "../src/backoff";
+
+const noJitter = { ...RECONNECT_DEFAULTS, jitter: false };
+
+describe("resolveReconnect", () => {
+    it("returns null when reconnection is disabled", () => {
+        expect(resolveReconnect(false)).toBeNull();
+    });
+
+    it("returns the defaults when no options are given", () => {
+        expect(resolveReconnect(undefined)).toEqual(RECONNECT_DEFAULTS);
+    });
+
+    it("merges partial options over the defaults", () => {
+        const resolved = resolveReconnect({ baseDelay: 100, maxRetries: 3 });
+        expect(resolved).toEqual({
+            ...RECONNECT_DEFAULTS,
+            baseDelay: 100,
+            maxRetries: 3
+        });
+    });
+});
+
+describe("computeDelay", () => {
+    it("grows exponentially without jitter", () => {
+        expect(computeDelay(0, noJitter)).toBe(500);
+        expect(computeDelay(1, noJitter)).toBe(1000);
+        expect(computeDelay(2, noJitter)).toBe(2000);
+        expect(computeDelay(3, noJitter)).toBe(4000);
+    });
+
+    it("caps at maxDelay", () => {
+        // 500 × 2^10 = 512_000 — far past the 30s cap.
+        expect(computeDelay(10, noJitter)).toBe(30_000);
+    });
+
+    it("applies full jitter over [0, exponential)", () => {
+        const opts = { ...RECONNECT_DEFAULTS, jitter: true };
+        expect(computeDelay(1, opts, () => 0)).toBe(0);
+        expect(computeDelay(1, opts, () => 0.5)).toBe(500);
+        expect(computeDelay(1, opts, () => 0.999)).toBeCloseTo(999);
+    });
+
+    it("jitters within the capped window", () => {
+        const opts = { ...RECONNECT_DEFAULTS, jitter: true };
+        expect(computeDelay(20, opts, () => 1)).toBe(30_000);
+    });
+
+    it("respects custom base and factor", () => {
+        const opts = { ...noJitter, baseDelay: 100, factor: 3 };
+        expect(computeDelay(0, opts)).toBe(100);
+        expect(computeDelay(1, opts)).toBe(300);
+        expect(computeDelay(2, opts)).toBe(900);
+    });
+});

--- a/packages/durablews/tests/client.test.ts
+++ b/packages/durablews/tests/client.test.ts
@@ -13,7 +13,9 @@ describe("client", () => {
 
     beforeEach(() => {
         server = new WS(URL);
-        ws = client({ url: URL });
+        // Reconnection is exercised by its own suite below; these tests verify
+        // the non-reconnect mechanics, so terminal-close semantics apply.
+        ws = client({ url: URL, reconnect: false });
     });
 
     afterEach(() => {
@@ -103,7 +105,7 @@ describe("client", () => {
         };
         const customUrl = "ws://localhost:1235";
         const customServer = new WS(customUrl);
-        const custom = client({ url: customUrl, codec });
+        const custom = client({ url: customUrl, codec, reconnect: false });
 
         const opened = custom.connect();
         await customServer.connected;
@@ -251,7 +253,11 @@ describe("client", () => {
         await connected();
         const snapshot = ws.getState();
         expect(Object.isFrozen(snapshot)).toBe(true);
-        expect(snapshot).toEqual({ state: "open", lastError: null });
+        expect(snapshot).toEqual({
+            state: "open",
+            lastError: null,
+            retryAttempt: 0
+        });
     });
 
     it("emits the full statechange sequence across a connect/close cycle", async () => {
@@ -272,5 +278,152 @@ describe("client", () => {
 
         await expect(ws.connect()).rejects.toThrow(/closing/);
         await server.closed;
+    });
+});
+
+describe("reconnection", () => {
+    const RURL = "ws://localhost:1240";
+    let server: WS;
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    async function open(c: WebSocketClient) {
+        const opened = c.connect();
+        await server.connected;
+        await opened;
+    }
+
+    it("retries an unexpected close: statechange → close → reconnecting", async () => {
+        server = new WS(RURL);
+        const c = client({
+            url: RURL,
+            reconnect: { baseDelay: 30_000, jitter: false }
+        });
+        const order: string[] = [];
+        c.on("statechange", ({ current }) => order.push(`state:${current}`));
+        c.on("close", () => order.push("close"));
+        c.on("reconnecting", ({ attempt, delay }) =>
+            order.push(`reconnecting:${attempt}:${delay}`)
+        );
+        await open(c);
+
+        server.close();
+        await vi.waitFor(() => expect(c.state).toBe("reconnecting"));
+
+        expect(order).toEqual([
+            "state:connecting",
+            "state:open",
+            "state:reconnecting",
+            "close",
+            "reconnecting:1:30000"
+        ]);
+        expect(c.getState().retryAttempt).toBe(1);
+        c.close();
+    });
+
+    it("reconnects when the server comes back and resets retryAttempt", async () => {
+        server = new WS(RURL);
+        const c = client({
+            url: RURL,
+            reconnect: { baseDelay: 10, jitter: false }
+        });
+        await open(c);
+
+        server.close();
+        WS.clean();
+        server = new WS(RURL);
+
+        await vi.waitFor(() => expect(c.state).toBe("open"), {
+            timeout: 2000
+        });
+        expect(c.getState().retryAttempt).toBe(0);
+        c.close();
+    });
+
+    it("connect() survives a down server and resolves on a successful retry", async () => {
+        // No server yet — the first attempt fails and retries begin.
+        const c = client({
+            url: RURL,
+            reconnect: { baseDelay: 10, jitter: false }
+        });
+        const opened = c.connect();
+        await vi.waitFor(() => expect(c.state).toBe("reconnecting"));
+
+        server = new WS(RURL);
+        await opened;
+        expect(c.state).toBe("open");
+        c.close();
+    });
+
+    it("rejects connect() once maxRetries is exhausted", async () => {
+        const c = client({
+            url: RURL,
+            reconnect: { baseDelay: 5, jitter: false, maxRetries: 2 }
+        });
+        await expect(c.connect()).rejects.toThrow(/gave up after 2 attempt/);
+        expect(c.state).toBe("closed");
+        expect(c.getState().retryAttempt).toBe(2);
+    });
+
+    it("honors a shouldReconnect veto", async () => {
+        server = new WS(RURL);
+        const c = client({
+            url: RURL,
+            reconnect: { shouldReconnect: () => false }
+        });
+        await open(c);
+
+        server.close();
+        await vi.waitFor(() => expect(c.state).toBe("closed"));
+        expect(c.getState().retryAttempt).toBe(0);
+    });
+
+    it("never reconnects after a user close()", async () => {
+        server = new WS(RURL);
+        const c = client({
+            url: RURL,
+            reconnect: { baseDelay: 5, jitter: false }
+        });
+        await open(c);
+
+        c.close();
+        await server.closed;
+        expect(c.state).toBe("closed");
+
+        // Give a would-be retry window time to fire, then re-assert.
+        await new Promise((r) => setTimeout(r, 30));
+        expect(c.state).toBe("closed");
+    });
+
+    it("close() during reconnecting cancels the retry and rejects connect()", async () => {
+        const c = client({
+            url: RURL,
+            reconnect: { baseDelay: 60_000, jitter: false }
+        });
+        const opened = c.connect();
+        await vi.waitFor(() => expect(c.state).toBe("reconnecting"));
+
+        c.close();
+        expect(c.state).toBe("closed");
+        await expect(opened).rejects.toThrow(/close\(\) called/);
+    });
+
+    it("connect() during reconnecting skips the backoff and attempts now", async () => {
+        const c = client({
+            url: RURL,
+            reconnect: { baseDelay: 60_000, jitter: false }
+        });
+        const opened = c.connect();
+        await vi.waitFor(() => expect(c.state).toBe("reconnecting"));
+
+        server = new WS(RURL);
+        const retried = c.connect();
+        await server.connected;
+        await retried;
+        await opened;
+        expect(c.state).toBe("open");
+        c.close();
     });
 });

--- a/packages/durablews/tests/fsm.test.ts
+++ b/packages/durablews/tests/fsm.test.ts
@@ -8,9 +8,13 @@ describe("connection FSM", () => {
         ["connecting", "OPEN", "open"],
         ["connecting", "CLOSE_REQUESTED", "closing"],
         ["connecting", "CLOSED", "closed"],
+        ["connecting", "RETRY", "reconnecting"],
         ["open", "CLOSE_REQUESTED", "closing"],
         ["open", "CLOSED", "closed"],
+        ["open", "RETRY", "reconnecting"],
         ["closing", "CLOSED", "closed"],
+        ["reconnecting", "CONNECT", "connecting"],
+        ["reconnecting", "CLOSE_REQUESTED", "closed"],
         ["closed", "CONNECT", "connecting"]
     ];
 
@@ -25,14 +29,22 @@ describe("connection FSM", () => {
         ["idle", "OPEN"],
         ["idle", "CLOSED"],
         ["idle", "CLOSE_REQUESTED"],
+        ["idle", "RETRY"],
         ["connecting", "CONNECT"],
         ["open", "CONNECT"],
         ["open", "OPEN"],
         ["closing", "CONNECT"],
         ["closing", "OPEN"],
+        ["closing", "RETRY"],
+        // No socket exists while waiting out the backoff, so socket-originated
+        // events cannot legally occur in `reconnecting`.
+        ["reconnecting", "OPEN"],
+        ["reconnecting", "CLOSED"],
+        ["reconnecting", "RETRY"],
         ["closed", "OPEN"],
         ["closed", "CLOSED"],
-        ["closed", "CLOSE_REQUESTED"]
+        ["closed", "CLOSE_REQUESTED"],
+        ["closed", "RETRY"]
     ];
 
     it.each(illegal)("%s + %s is illegal", (from, event) => {

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -486,10 +486,16 @@ harness already exists, so each slice carries its own unit + integration + e2e
 coverage *and* its docs update ("roadmap → what works today") in-PR — there is no
 separate test/e2e slice.
 
-- 🚧 **Slice 1 — Reconnection + backoff.** `reconnecting` FSM state; backoff
-  scheduler (fake-timer-tested); retryable-close policy; `reconnecting` event;
-  `connect()` terminal semantics tightened to retries-exhausted. E2e: server
-  drops the socket → transparent reconnect.
+- ✅ **Slice 1 — Reconnection + backoff.** `reconnecting` FSM state +
+  `RETRY` event; pure backoff module (`backoff.ts` — full-jitter math with
+  injectable randomness, deterministically unit-tested); retryable-close policy
+  (user `close()` never retried; `shouldReconnect` veto; `maxRetries` budget);
+  `reconnecting` event (`{ attempt, delay }`, ordered statechange → close →
+  reconnecting); `retryAttempt` joins `getState()`. `connect()` survives failed
+  attempts and settles only on first open or terminal failure
+  (retries-exhausted / veto / user close-before-open); manual `connect()`
+  during `reconnecting` skips the backoff wait. E2e: server drops the socket
+  (code 1012) → real Chromium transparently reconnects and round-trips.
 - ⬜ **Slice 2 — Message queueing.** `send()` queues while not-open; bounded
   with drop-oldest + `drop` event; flush-on-(re)open (rides slice 1's reconnect).
   E2e: queued sends flush after a reconnect.
@@ -542,12 +548,13 @@ completes; scope is tracked here so it doesn't get lost:
   `error`/`statechange`). Option names refined as each seam lands.
 - Whether channels are the only plugin-shaped feature (which would let us drop
   the umbrella "plugin" concept from the public vocabulary).
-- **`connect()` can never settle under default config.** With
-  `maxRetries: Infinity` (the M3 default), "rejects on retries-exhausted" means
-  the promise never rejects — an app `await`ing `connect()` against a dead host
-  hangs silently. Arguably correct for "durable by default," but decide: add a
-  `connectTimeout` option, or document the hang as intended? (Decide in M3
-  slice 1.)
+- ~~`connect()` can never settle under default config.~~ **Settled in M3
+  slice 1: pending-forever is by design.** Under `maxRetries: Infinity` the
+  client is *still working* — a rejection would be a lie, and a built-in
+  `connectTimeout` would duplicate what userland does in one line
+  (`Promise.race([client.connect(), timeout(ms)])`) while complicating the
+  contract. Escape hatches: finite `maxRetries`, `shouldReconnect`, or the
+  race. Documented prominently in the `connect()` JSDoc and getting-started.
 - **`durablews/compat`** — ship a drop-in `WebSocket`-shaped wrapper to capture
   the `reconnecting-websocket`/`partysocket` migration audience, or explicitly
   reject it? (Decide in M4; see §2.1.)


### PR DESCRIPTION
**M3 slice 1 of 3 — the headline durability feature.** An unexpected disconnect now transparently recovers, with zero configuration.

## What changed
- **`backoff.ts`** — pure full-jitter exponential backoff (`random(0, min(maxDelay, baseDelay × factorⁿ))`) with injectable randomness, deterministically unit-tested. Defaults per the RFC: 500ms base, ×2, 30s cap, jitter on, **unlimited retries**.
- **FSM** — new `reconnecting` state + `RETRY` event. While waiting out the backoff no socket exists, so `OPEN`/`CLOSED` are *illegal* in `reconnecting` (the table proves it) and `close()` goes straight to `closed`.
- **Retry policy** — reconnect on any close not initiated by the user's `close()`, gated by `shouldReconnect(closeEvent)` and `maxRetries`. Event order on a retryable close: `statechange` → `close` → `reconnecting({ attempt, delay })` — built for UIs ("retry #2 in 3s"). `retryAttempt` joins `getState()`.
- **`connect()` contract tightened as planned** — the promise survives failed attempts and settles only on first open or terminal failure. Manual `connect()` during `reconnecting` skips the rest of the wait.
- **§9 decision settled: pending-forever is by design.** Under `maxRetries: Infinity` a rejection would be a lie — the client is still working. Deadline-needing apps race the promise or set finite `maxRetries`. Documented in JSDoc + getting-started.
- Config: `reconnect?: false | ReconnectOptions`; exports `ReconnectOptions`, `ReconnectingEvent`, `RECONNECT_DEFAULTS`.

## Tests (87 unit/integration + 3 e2e, all green)
- Backoff math: growth, cap, jitter range, option merging — deterministic via injected random.
- FSM matrix extended to 29 cases (incl. all illegal `reconnecting` pairs).
- 8 reconnection integration tests: event order, server-comes-back recovery, `connect()` surviving a down server, `maxRetries` rejection, `shouldReconnect` veto, user-close never retries, `close()` during the wait cancels + rejects, manual `connect()` skips the wait.
- **E2e:** echo server force-drops the connection (1012) → real Chromium transparently reconnects and round-trips a message after recovery.
- M2-mechanics tests pinned to `reconnect: false` (terminal-close semantics preserved there); `typecheck:next` clean on today's nightly.

## Docs
Reconnection moved to "what works today" (with the `connect()`/Infinity note); RFC slice 1 ✅.

**Next:** slice 2 — message queueing (`send()` queues while disconnected, flushes on reconnect — rides this slice's machinery).