### PR TITLE
feat(core): message queueing while disconnected (M3 slice 2)

### DIFF
--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -51,11 +51,17 @@ client.close();
   `reconnecting` event (`{ attempt, delay }`) keeps your UI informed. Tune or
   disable via the `reconnect` option (`baseDelay`, `factor`, `maxDelay`,
   `jitter`, `maxRetries`, `shouldReconnect`, or `reconnect: false`).
+- **Message queueing while disconnected, on by default** — `send()` during
+  `connecting`/`reconnecting` queues (bounded, 256 by default) and flushes in
+  order when the socket opens. Dropped messages are never silent: every one
+  fires a `drop` event (`{ data, reason }`). Tune via `queue: { maxSize }` or
+  restore throw-when-not-open with `queue: false`.
 - Connect / send / close over the standard `WebSocket`, driven by an explicit
   connection state machine
 - Incoming-message handling and lifecycle events (`open`, `message`, `close`,
-  `error`, `statechange`, `reconnecting`) via `on()`
-- A read-only `state` and `getState()` snapshot (incl. `retryAttempt`)
+  `error`, `statechange`, `reconnecting`, `drop`) via `on()`
+- A read-only `state` and `getState()` snapshot (incl. `retryAttempt` and
+  `queueLength`)
 - A pluggable wire-format codec (`codec` option; JSON by default)
 - A message middleware pipeline (`use()`), with an opt-in `pingpong` keepalive
 
@@ -69,8 +75,7 @@ it: `Promise.race([client.connect(), timeout(10_000)])`.
 
 ## On the roadmap
 
-Message queueing while disconnected, idle detection (opt-in heartbeat), and
-channels. Until these land, treat them as a roadmap rather than a guarantee —
-see the
+Idle detection (opt-in heartbeat) and channels. Until these land, treat them as
+a roadmap rather than a guarantee — see the
 [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
 for the full plan and status.

--- a/packages/durablews/e2e/client.e2e.ts
+++ b/packages/durablews/e2e/client.e2e.ts
@@ -111,3 +111,44 @@ test("transparently reconnects when the server drops the connection", async ({
     expect(result.recovered).toBe("open");
     expect(result.echoed).toContain("after-reconnect");
 });
+
+test("flushes messages queued while disconnected once reconnected", async ({
+    page
+}) => {
+    await page.goto("/e2e/app.html");
+
+    const result = await page.evaluate(async (wsUrl) => {
+        const { defineClient } = await import("/dist/index.js");
+        const ws = defineClient({
+            url: wsUrl,
+            reconnect: { baseDelay: 50, jitter: false }
+        });
+        const echoed: unknown[] = [];
+        ws.on("message", (m: unknown) => echoed.push(m));
+
+        await ws.connect();
+        const droppedToReconnecting = new Promise<void>((resolve) => {
+            ws.on("statechange", ({ current }: { current: string }) => {
+                if (current === "reconnecting") {
+                    resolve();
+                }
+            });
+        });
+
+        ws.send("drop"); // server closes this connection
+        await droppedToReconnecting;
+
+        ws.send("queued-while-down"); // no socket exists: this must queue
+        const queuedLength = ws.getState().queueLength;
+
+        await new Promise((r) => setTimeout(r, 600)); // reconnect + flush
+        const finalState = ws.state;
+        ws.close();
+
+        return { queuedLength, echoed, finalState };
+    }, `ws://localhost:${server.port}`);
+
+    expect(result.queuedLength).toBe(1);
+    expect(result.finalState).toBe("open");
+    expect(result.echoed).toContain("queued-while-down");
+});

--- a/packages/durablews/src/client.ts
+++ b/packages/durablews/src/client.ts
@@ -3,6 +3,7 @@ import { jsonCodec } from "@/codec";
 import { nextState } from "@/fsm";
 import { defineEventBus } from "@/helpers/event-bus";
 import { runPipeline } from "@/pipeline";
+import { resolveQueue } from "@/queue";
 import type {
     ClientEventMap,
     ClientState,
@@ -41,7 +42,13 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
     const bus = defineEventBus();
     const codec = config.codec ?? jsonCodec;
     const reconnect = resolveReconnect(config.reconnect);
+    const queue = resolveQueue(config.queue);
     const middlewares: Middleware[] = [];
+
+    // Outbound messages awaiting an open socket, in send() order. Original
+    // (un-encoded) values: encoding happens at flush, so a drop event can hand
+    // the user back exactly what they passed to send().
+    const queued: unknown[] = [];
 
     let socket: WebSocket | null = null;
     let state: ConnectionState = "idle";
@@ -100,6 +107,33 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
     }
 
     /**
+     * Sends every queued message in order. Called once the socket opens,
+     * *before* the `open` event, so the backlog (sent earlier in time)
+     * precedes anything an `open` handler sends. A per-message encode/send
+     * failure surfaces as an `error` event and flushing continues.
+     */
+    function flushQueue() {
+        while (queued.length > 0 && socket && state === "open") {
+            const data = queued.shift();
+            try {
+                socket.send(codec.encode(data));
+            } catch (error) {
+                bus.emit("error", toError(error));
+            }
+        }
+    }
+
+    /**
+     * Empties the queue as `drop` events — these messages will never be sent
+     * (user `close()` or terminal failure). Never silently lossy.
+     */
+    function dropQueued() {
+        while (queued.length > 0) {
+            bus.emit("drop", { data: queued.shift(), reason: "close" });
+        }
+    }
+
+    /**
      * Whether an unexpected close should be retried: reconnection enabled, not
      * a user `close()`, retries left, and no `shouldReconnect` veto.
      */
@@ -121,6 +155,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         socket.onopen = () => {
             retryAttempt = 0;
             transition("OPEN");
+            flushQueue();
             bus.emit("open");
             settleConnected();
         };
@@ -157,6 +192,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
             }
 
             transition("CLOSED");
+            dropQueued();
             bus.emit("close", event);
             // Terminal for any in-flight connect(): closed before first open
             // with no (further) retries coming.
@@ -261,18 +297,36 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         },
 
         send(data: unknown) {
-            if (!socket || state !== "open") {
-                throw new Error(
-                    `Cannot send: connection is not open (state: "${state}")`
-                );
+            if (socket && state === "open") {
+                socket.send(codec.encode(data));
+                return;
             }
-            socket.send(codec.encode(data));
+            // An open is coming (or being retried): queue, bounded drop-oldest.
+            if (
+                queue !== null &&
+                (state === "connecting" || state === "reconnecting")
+            ) {
+                if (queued.length >= queue.maxSize) {
+                    bus.emit("drop", {
+                        data: queued.shift(),
+                        reason: "overflow"
+                    });
+                }
+                queued.push(data);
+                return;
+            }
+            throw new Error(
+                `Cannot send: connection is not open (state: "${state}")`
+            );
         },
 
         close(code?: number, reason?: string) {
             closeRequested = true;
             clearRetryTimer();
             retryAttempt = 0;
+            // The user hung up: queued messages will never send. Surface them
+            // now (deterministically), not when the socket finishes closing.
+            dropQueued();
 
             if (state === "reconnecting") {
                 // No socket exists while waiting out the backoff: go straight
@@ -304,7 +358,12 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         },
 
         getState(): ClientState {
-            return Object.freeze({ state, lastError, retryAttempt });
+            return Object.freeze({
+                state,
+                lastError,
+                retryAttempt,
+                queueLength: queued.length
+            });
         }
     };
 

--- a/packages/durablews/src/index.ts
+++ b/packages/durablews/src/index.ts
@@ -19,13 +19,16 @@ export function defineClient(config: WebSocketClientConfig): WebSocketClient {
 export { RECONNECT_DEFAULTS } from "@/backoff";
 export { jsonCodec } from "@/codec";
 export { pingpong } from "@/middleware";
+export { QUEUE_DEFAULTS } from "@/queue";
 export type {
     ClientEventMap,
     ClientState,
     Codec,
     ConnectionState,
+    DropEvent,
     MessageContext,
     Middleware,
+    QueueOptions,
     ReconnectingEvent,
     ReconnectOptions,
     StateChange,

--- a/packages/durablews/src/queue.ts
+++ b/packages/durablews/src/queue.ts
@@ -1,0 +1,26 @@
+import type { QueueOptions } from "@/types";
+
+/** `QueueOptions` with every field filled in. */
+export type ResolvedQueue = Required<QueueOptions>;
+
+/**
+ * The default outbound-queue policy: bounded at 256 messages, drop-oldest.
+ * Never silently unbounded (a memory leak), never silently lossy (every drop
+ * emits a `drop` event). See the RFC's M3 decisions.
+ */
+export const QUEUE_DEFAULTS: ResolvedQueue = {
+    maxSize: 256
+};
+
+/**
+ * Resolve the user's `queue` config: `false` disables queueing entirely
+ * (`null`), anything else is merged over the defaults.
+ */
+export function resolveQueue(
+    option: false | QueueOptions | undefined
+): ResolvedQueue | null {
+    if (option === false) {
+        return null;
+    }
+    return { ...QUEUE_DEFAULTS, ...option };
+}

--- a/packages/durablews/src/types.ts
+++ b/packages/durablews/src/types.ts
@@ -48,6 +48,18 @@ export interface ReconnectOptions {
 }
 
 /**
+ * Tuning for the outbound message queue.
+ */
+export interface QueueOptions {
+    /**
+     * Maximum queued messages. When full, the **oldest** is dropped and a
+     * `drop` event fires — never silently unbounded, never silently lossy.
+     * Default `256`.
+     */
+    readonly maxSize?: number;
+}
+
+/**
  * Configuration options for the WebSocket client.
  */
 export interface WebSocketClientConfig {
@@ -62,6 +74,12 @@ export interface WebSocketClientConfig {
      * `false` to disable, or options to tune the backoff.
      */
     readonly reconnect?: false | ReconnectOptions;
+    /**
+     * Outbound queueing while disconnected — **on by default**. `send()`
+     * during `connecting`/`reconnecting` queues and flushes in order on open.
+     * Pass `false` to make `send()` throw whenever the socket isn't open.
+     */
+    readonly queue?: false | QueueOptions;
 }
 
 /**
@@ -112,6 +130,23 @@ export interface ClientState {
      * resets on a successful open or a user `close()`.
      */
     readonly retryAttempt: number;
+    /** Messages currently waiting in the outbound queue. */
+    readonly queueLength: number;
+}
+
+/**
+ * Payload emitted on every `drop` event — a queued outbound message that will
+ * never be sent.
+ */
+export interface DropEvent {
+    /** The original (un-encoded) value passed to `send()`. */
+    readonly data: unknown;
+    /**
+     * Why it was dropped: `overflow` — the queue was full and this was the
+     * oldest entry; `close` — the connection ended (user `close()` or terminal
+     * failure) with messages still queued.
+     */
+    readonly reason: "overflow" | "close";
 }
 
 /**
@@ -180,6 +215,8 @@ export interface ClientEventMap {
     statechange: StateChange;
     /** A reconnect attempt was scheduled (fires once per retry). */
     reconnecting: ReconnectingEvent;
+    /** A queued outbound message was dropped and will never be sent. */
+    drop: DropEvent;
 }
 
 /**
@@ -217,7 +254,13 @@ export interface WebSocketClient {
 
     /**
      * Sends data over the connection. Non-string data is encoded (JSON by
-     * default). Throws if the connection is not open.
+     * default).
+     *
+     * While `connecting` or `reconnecting`, the message is **queued** (bounded,
+     * drop-oldest — see `queue` config) and flushed in order when the socket
+     * opens; queued messages that will never send surface as `drop` events.
+     * Throws when the client is `idle`, `closing`, or `closed` — states where
+     * no open is coming — or whenever the socket isn't open if `queue: false`.
      */
     send(data: unknown): void;
 

--- a/packages/durablews/tests/client.test.ts
+++ b/packages/durablews/tests/client.test.ts
@@ -256,7 +256,8 @@ describe("client", () => {
         expect(snapshot).toEqual({
             state: "open",
             lastError: null,
-            retryAttempt: 0
+            retryAttempt: 0,
+            queueLength: 0
         });
     });
 
@@ -425,5 +426,142 @@ describe("reconnection", () => {
         await opened;
         expect(c.state).toBe("open");
         c.close();
+    });
+});
+
+describe("outbound queue", () => {
+    const QURL = "ws://localhost:1241";
+    let server: WS;
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    it("queues sends while connecting and flushes in order on open", async () => {
+        server = new WS(QURL);
+        const c = client({ url: QURL, reconnect: false });
+
+        const opened = c.connect();
+        c.send("first");
+        c.send({ n: 2 });
+        expect(c.state).toBe("connecting");
+        expect(c.getState().queueLength).toBe(2);
+
+        await server.connected;
+        await opened;
+
+        await expect(server).toReceiveMessage("first");
+        await expect(server).toReceiveMessage(JSON.stringify({ n: 2 }));
+        expect(c.getState().queueLength).toBe(0);
+        c.close();
+    });
+
+    it("queues sends while reconnecting and flushes after recovery", async () => {
+        server = new WS(QURL);
+        const c = client({
+            url: QURL,
+            reconnect: { baseDelay: 10, jitter: false }
+        });
+        const opened = c.connect();
+        await server.connected;
+        await opened;
+
+        server.close();
+        await vi.waitFor(() => expect(c.state).toBe("reconnecting"));
+        c.send("while-down");
+        expect(c.getState().queueLength).toBe(1);
+
+        WS.clean();
+        server = new WS(QURL);
+        await vi.waitFor(() => expect(c.state).toBe("open"), {
+            timeout: 2000
+        });
+        await expect(server).toReceiveMessage("while-down");
+        expect(c.getState().queueLength).toBe(0);
+        c.close();
+    });
+
+    it("drops the oldest message on overflow, with a drop event", async () => {
+        server = new WS(QURL);
+        const c = client({
+            url: QURL,
+            reconnect: false,
+            queue: { maxSize: 2 }
+        });
+        const drops = vi.fn();
+        c.on("drop", drops);
+
+        const opened = c.connect();
+        c.send("a");
+        c.send("b");
+        c.send("c"); // overflows: "a" is dropped
+
+        expect(drops).toHaveBeenCalledWith({ data: "a", reason: "overflow" });
+        expect(c.getState().queueLength).toBe(2);
+
+        await server.connected;
+        await opened;
+        await expect(server).toReceiveMessage("b");
+        await expect(server).toReceiveMessage("c");
+        c.close();
+    });
+
+    it("queue: false restores throw-when-not-open", async () => {
+        server = new WS(QURL);
+        const c = client({ url: QURL, reconnect: false, queue: false });
+        c.connect().catch(() => {});
+        expect(c.state).toBe("connecting");
+        expect(() => c.send("nope")).toThrow(/not open/);
+        c.close();
+    });
+
+    it("still throws when idle — no open is coming", () => {
+        const c = client({ url: QURL });
+        expect(() => c.send("nope")).toThrow(/not open/);
+    });
+
+    it("user close() drops queued messages as drop events", async () => {
+        server = new WS(QURL);
+        const c = client({ url: QURL, reconnect: false });
+        const drops = vi.fn();
+        c.on("drop", drops);
+
+        c.connect().catch(() => {});
+        c.send("never-sent");
+        expect(c.getState().queueLength).toBe(1);
+
+        c.close();
+        expect(drops).toHaveBeenCalledWith({
+            data: "never-sent",
+            reason: "close"
+        });
+        expect(c.getState().queueLength).toBe(0);
+    });
+
+    it("terminal failure drops queued messages as drop events", async () => {
+        // No server: retries exhaust, the close is terminal.
+        const c = client({
+            url: QURL,
+            reconnect: { baseDelay: 5, jitter: false, maxRetries: 1 }
+        });
+        const drops = vi.fn();
+        c.on("drop", drops);
+
+        // Queue synchronously the moment the (only) retry is scheduled — the
+        // reconnecting window is too brief to poll for.
+        c.on("reconnecting", ({ attempt }) => {
+            if (attempt === 1) {
+                c.send("doomed");
+            }
+        });
+
+        const opened = c.connect();
+        await expect(opened).rejects.toThrow(/gave up/);
+        expect(c.state).toBe("closed");
+        expect(drops).toHaveBeenCalledWith({
+            data: "doomed",
+            reason: "close"
+        });
+        expect(c.getState().queueLength).toBe(0);
     });
 });

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -496,9 +496,15 @@ separate test/e2e slice.
   (retries-exhausted / veto / user close-before-open); manual `connect()`
   during `reconnecting` skips the backoff wait. E2e: server drops the socket
   (code 1012) → real Chromium transparently reconnects and round-trips.
-- ⬜ **Slice 2 — Message queueing.** `send()` queues while not-open; bounded
-  with drop-oldest + `drop` event; flush-on-(re)open (rides slice 1's reconnect).
-  E2e: queued sends flush after a reconnect.
+- ✅ **Slice 2 — Message queueing.** `send()` queues during
+  `connecting`/`reconnecting` (un-encoded values, so `drop` hands back exactly
+  what was passed); bounded drop-oldest (`queue.ts`, default 256) with a `drop`
+  event (`{ data, reason: "overflow" | "close" }`); flush in order on open,
+  *before* the `open` event (backlog precedes anything an open-handler sends);
+  user `close()` and terminal failure drop the queue as `drop` events — never
+  silently lossy. `queueLength` joins `getState()`; `send()` still throws in
+  `idle`/`closing`/`closed` and (always) under `queue: false`. E2e: a message
+  sent while the server is down flushes after the transparent reconnect.
 - ⬜ **Slice 3 — Idle detection / heartbeat.** Opt-in keepalive + liveness
   timeout that forces a reconnect on a silent link. E2e: heartbeat-triggered
   recovery.


### PR DESCRIPTION
**M3 slice 2 of 3.** `send()` during `connecting`/`reconnecting` now queues instead of throwing, and the backlog flushes in order the moment the socket opens — riding slice 1's reconnect, so messages sent while the server is down arrive after recovery. This is the feature `partysocket` doesn't have (§2.1).

## What changed
- **`queue.ts`** — `QUEUE_DEFAULTS` (maxSize 256) + `resolveQueue`; config `queue?: false | { maxSize? }`. `queue: false` restores throw-when-not-open.
- **Bounded, drop-oldest, never silent** — overflow drops the oldest with a `drop` event (`{ data, reason: "overflow" }`). The queue holds the original *un-encoded* values, so `drop` hands back exactly what was passed to `send()`; encoding happens at flush, and a per-message encode failure surfaces as an `error` event without halting the flush.
- **Flush before the `open` event** — the backlog was sent earlier in time, so it precedes anything an open-handler sends.
- **Close paths drain as `drop` events** — user `close()` drops immediately (deterministic); terminal failure (retries exhausted / veto) drops at the terminal close. Reason: `"close"`.
- **`queueLength`** joins `getState()`. `send()` still throws in `idle`/`closing`/`closed` — states where no open is coming.

## Tests
- 7 queue integration tests: flush order, queue-across-reconnect, overflow + drop event, `queue: false`, idle-throws, close-drop, terminal-drop — **94 unit/integration green**.
- **E2e:** a message sent while the server is down flushes after the transparent reconnect (**4 e2e green**).
- `typecheck:next` clean on today's nightly.

## Docs
Queueing moved to "what works today" (with `drop`/`queueLength`); RFC slice 2 ✅.

**Next:** slice 3 — opt-in heartbeat / idle detection, which completes M3.