### PR TITLE
feat(core): opt-in heartbeat / idle detection (M3 slice 3 — completes M3)

### DIFF
--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -56,6 +56,11 @@ client.close();
   order when the socket opens. Dropped messages are never silent: every one
   fires a `drop` event (`{ data, reason }`). Tune via `queue: { maxSize }` or
   restore throw-when-not-open with `queue: false`.
+- **Heartbeat / idle detection, opt-in** — set
+  `heartbeat: { interval, message?, timeout? }` and the client pings while
+  open; if no inbound traffic answers within `timeout`, the link is declared
+  dead (close code `4408`) and the normal reconnect machinery takes over.
+  Opt-in because it requires a server that answers the ping.
 - Connect / send / close over the standard `WebSocket`, driven by an explicit
   connection state machine
 - Incoming-message handling and lifecycle events (`open`, `message`, `close`,
@@ -75,7 +80,6 @@ it: `Promise.race([client.connect(), timeout(10_000)])`.
 
 ## On the roadmap
 
-Idle detection (opt-in heartbeat) and channels. Until these land, treat them as
-a roadmap rather than a guarantee — see the
+Framework bindings (React first), typed message maps, and channels — see the
 [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
 for the full plan and status.

--- a/packages/durablews/e2e/client.e2e.ts
+++ b/packages/durablews/e2e/client.e2e.ts
@@ -152,3 +152,52 @@ test("flushes messages queued while disconnected once reconnected", async ({
     expect(result.finalState).toBe("open");
     expect(result.echoed).toContain("queued-while-down");
 });
+
+test("heartbeat detects a silent link and recovers through reconnect", async ({
+    page
+}) => {
+    await page.goto("/e2e/app.html");
+
+    const result = await page.evaluate(async (wsUrl) => {
+        const { defineClient } = await import("/dist/index.js");
+        const ws = defineClient({
+            url: wsUrl,
+            reconnect: { baseDelay: 50, jitter: false },
+            heartbeat: { interval: 100, timeout: 80 }
+        });
+        const states: string[] = [];
+        ws.on("statechange", ({ current }: { current: string }) =>
+            states.push(current)
+        );
+        const errors: string[] = [];
+        ws.on("error", (e: unknown) => {
+            if (e instanceof Error) {
+                errors.push(e.message);
+            }
+        });
+        const closeCodes: number[] = [];
+        ws.on("close", (e: { code: number }) => closeCodes.push(e.code));
+
+        await ws.connect();
+        ws.send("mute"); // the server goes silent on this connection
+
+        // Silent link: pings get no reply → 4408 close → reconnect lands on a
+        // fresh, unmuted connection.
+        await new Promise((r) => setTimeout(r, 800));
+        const recovered = ws.state;
+
+        const echoed: unknown[] = [];
+        ws.on("message", (m: unknown) => echoed.push(m));
+        ws.send("alive-again");
+        await new Promise((r) => setTimeout(r, 200));
+        ws.close();
+
+        return { states, errors, closeCodes, recovered, echoed };
+    }, `ws://localhost:${server.port}`);
+
+    expect(result.errors.some((m) => /heartbeat timeout/i.test(m))).toBe(true);
+    expect(result.closeCodes).toContain(4408);
+    expect(result.states).toContain("reconnecting");
+    expect(result.recovered).toBe("open");
+    expect(result.echoed).toContain("alive-again");
+});

--- a/packages/durablews/e2e/echo-server.mjs
+++ b/packages/durablews/e2e/echo-server.mjs
@@ -2,10 +2,12 @@ import { WebSocketServer } from "ws";
 
 /**
  * Starts a throwaway WebSocket server on a random free port for the browser
- * e2e tests. It echoes any message back, with two special textual commands:
- * "ping" is answered with "pong" (pingpong middleware), and "drop" makes the
- * server close that connection — the server stays up, so a reconnecting
- * client can come back (reconnection e2e).
+ * e2e tests. It echoes any message back, with three special textual commands:
+ * "ping" is answered with "pong" (pingpong middleware); "drop" makes the
+ * server close that connection; "mute" makes the server stop responding on
+ * that connection (a silent-but-open link, for the heartbeat e2e). The server
+ * itself stays up, so a reconnecting client always gets a fresh, unmuted
+ * connection.
  *
  * @returns the chosen port and a close() that resolves once the server is down.
  */
@@ -22,8 +24,16 @@ export function startEchoServer() {
         });
 
         wss.on("connection", (socket) => {
+            let muted = false;
             socket.on("message", (data) => {
                 const text = data.toString();
+                if (text === "mute") {
+                    muted = true;
+                    return;
+                }
+                if (muted) {
+                    return;
+                }
                 if (text === "drop") {
                     socket.close(1012, "server drop");
                     return;

--- a/packages/durablews/src/client.ts
+++ b/packages/durablews/src/client.ts
@@ -1,6 +1,7 @@
 import { computeDelay, resolveReconnect } from "@/backoff";
 import { jsonCodec } from "@/codec";
 import { nextState } from "@/fsm";
+import { HEARTBEAT_TIMEOUT_CODE, resolveHeartbeat } from "@/heartbeat";
 import { defineEventBus } from "@/helpers/event-bus";
 import { runPipeline } from "@/pipeline";
 import { resolveQueue } from "@/queue";
@@ -43,6 +44,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
     const codec = config.codec ?? jsonCodec;
     const reconnect = resolveReconnect(config.reconnect);
     const queue = resolveQueue(config.queue);
+    const heartbeat = resolveHeartbeat(config.heartbeat);
     const middlewares: Middleware[] = [];
 
     // Outbound messages awaiting an open socket, in send() order. Original
@@ -52,7 +54,13 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
 
     let socket: WebSocket | null = null;
     let state: ConnectionState = "idle";
-    let lastError: Event | null = null;
+    let lastError: Event | Error | null = null;
+
+    // Heartbeat bookkeeping: when the last inbound frame (of any kind)
+    // arrived, the ping interval, and the per-ping liveness deadline.
+    let lastInboundAt = 0;
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    let heartbeatDeadline: ReturnType<typeof setTimeout> | null = null;
 
     // True between a user close() and the next connect(); suppresses
     // reconnection so "the user hung up" is never retried.
@@ -106,6 +114,56 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         }
     }
 
+    function stopHeartbeat() {
+        if (heartbeatTimer !== null) {
+            clearInterval(heartbeatTimer);
+            heartbeatTimer = null;
+        }
+        if (heartbeatDeadline !== null) {
+            clearTimeout(heartbeatDeadline);
+            heartbeatDeadline = null;
+        }
+    }
+
+    /**
+     * While open, sends the heartbeat message every `interval` ms and arms a
+     * liveness deadline after each ping. Any inbound frame before the deadline
+     * proves the link; none means it's dead — force-close with code 4408,
+     * which flows into the normal reconnect machinery (the close is not
+     * user-initiated, so it is retryable).
+     */
+    function startHeartbeat() {
+        if (heartbeat === null) {
+            return;
+        }
+        stopHeartbeat();
+        heartbeatTimer = setInterval(() => {
+            if (state !== "open" || !socket) {
+                return;
+            }
+            const pingSentAt = Date.now();
+            try {
+                socket.send(codec.encode(heartbeat.message));
+            } catch (error) {
+                bus.emit("error", toError(error));
+            }
+            if (heartbeatDeadline !== null) {
+                clearTimeout(heartbeatDeadline);
+            }
+            heartbeatDeadline = setTimeout(() => {
+                heartbeatDeadline = null;
+                if (state === "open" && socket && lastInboundAt < pingSentAt) {
+                    const failure = new Error(
+                        `Heartbeat timeout: no inbound traffic within ${heartbeat.timeout}ms of a ping`
+                    );
+                    lastError = failure;
+                    bus.emit("error", failure);
+                    socket.close(HEARTBEAT_TIMEOUT_CODE, "heartbeat timeout");
+                }
+            }, heartbeat.timeout);
+        }, heartbeat.interval);
+    }
+
     /**
      * Sends every queued message in order. Called once the socket opens,
      * *before* the `open` event, so the backlog (sent earlier in time)
@@ -156,11 +214,13 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
             retryAttempt = 0;
             transition("OPEN");
             flushQueue();
+            startHeartbeat();
             bus.emit("open");
             settleConnected();
         };
 
         socket.onmessage = (event: MessageEvent) => {
+            lastInboundAt = Date.now();
             deliver(event.data);
         };
 
@@ -172,6 +232,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         socket.onclose = (event: CloseEvent) => {
             const wasConnecting = state === "connecting";
             socket = null;
+            stopHeartbeat();
 
             if (reconnect !== null && isRetryable(event)) {
                 // Event order is deliberate: statechange (state already moved
@@ -323,6 +384,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         close(code?: number, reason?: string) {
             closeRequested = true;
             clearRetryTimer();
+            stopHeartbeat();
             retryAttempt = 0;
             // The user hung up: queued messages will never send. Surface them
             // now (deterministically), not when the socket finishes closing.

--- a/packages/durablews/src/heartbeat.ts
+++ b/packages/durablews/src/heartbeat.ts
@@ -1,0 +1,34 @@
+import type { HeartbeatOptions } from "@/types";
+
+/** `HeartbeatOptions` with every field filled in. */
+export interface ResolvedHeartbeat {
+    readonly interval: number;
+    readonly message: unknown;
+    readonly timeout: number;
+}
+
+/**
+ * The close code used when the heartbeat declares the link dead (app-reserved
+ * 4xxx range, mnemonic for HTTP 408 Request Timeout). Useful in a custom
+ * `shouldReconnect` to distinguish heartbeat closes from server closes.
+ */
+export const HEARTBEAT_TIMEOUT_CODE = 4408;
+
+/**
+ * Resolve the user's `heartbeat` config. Heartbeat is **opt-in**: absence means
+ * off (`null`) — a naive "no traffic → reconnect" would kill legitimately
+ * quiet-but-healthy connections, and any ping depends on app-level semantics
+ * the library can't assume (see the RFC's M3 decisions).
+ */
+export function resolveHeartbeat(
+    option: HeartbeatOptions | undefined
+): ResolvedHeartbeat | null {
+    if (option === undefined) {
+        return null;
+    }
+    return {
+        interval: option.interval,
+        message: option.message ?? "ping",
+        timeout: option.timeout ?? option.interval
+    };
+}

--- a/packages/durablews/src/index.ts
+++ b/packages/durablews/src/index.ts
@@ -18,6 +18,7 @@ export function defineClient(config: WebSocketClientConfig): WebSocketClient {
 
 export { RECONNECT_DEFAULTS } from "@/backoff";
 export { jsonCodec } from "@/codec";
+export { HEARTBEAT_TIMEOUT_CODE } from "@/heartbeat";
 export { pingpong } from "@/middleware";
 export { QUEUE_DEFAULTS } from "@/queue";
 export type {
@@ -26,6 +27,7 @@ export type {
     Codec,
     ConnectionState,
     DropEvent,
+    HeartbeatOptions,
     MessageContext,
     Middleware,
     QueueOptions,

--- a/packages/durablews/src/types.ts
+++ b/packages/durablews/src/types.ts
@@ -48,6 +48,28 @@ export interface ReconnectOptions {
 }
 
 /**
+ * Opt-in liveness checking. When configured, the client sends `message` every
+ * `interval` ms while open; if **no inbound frame of any kind** arrives within
+ * `timeout` ms of a ping, the link is declared dead and force-closed (code
+ * `4408`), which flows into the normal reconnect machinery.
+ *
+ * Requires a server that responds to the heartbeat message (or talks
+ * regularly for other reasons) — that app-level contract is why heartbeat is
+ * opt-in rather than on by default.
+ */
+export interface HeartbeatOptions {
+    /** Milliseconds between pings. */
+    readonly interval: number;
+    /** The ping payload, run through the codec. Default `"ping"`. */
+    readonly message?: unknown;
+    /**
+     * Milliseconds after a ping to wait for inbound traffic before declaring
+     * the link dead. Default: `interval`.
+     */
+    readonly timeout?: number;
+}
+
+/**
  * Tuning for the outbound message queue.
  */
 export interface QueueOptions {
@@ -80,6 +102,11 @@ export interface WebSocketClientConfig {
      * Pass `false` to make `send()` throw whenever the socket isn't open.
      */
     readonly queue?: false | QueueOptions;
+    /**
+     * Liveness checking — **opt-in** (off unless configured). See
+     * {@link HeartbeatOptions}.
+     */
+    readonly heartbeat?: HeartbeatOptions;
 }
 
 /**
@@ -123,8 +150,11 @@ export type ConnectionEvent =
 export interface ClientState {
     /** The current connection state. */
     readonly state: ConnectionState;
-    /** The most recent transport error, if any. */
-    readonly lastError: Event | null;
+    /**
+     * The most recent failure, if any: a transport error (`Event`) or a
+     * client-detected one like a heartbeat timeout (`Error`).
+     */
+    readonly lastError: Event | Error | null;
     /**
      * Retries used in the current disconnection episode. `0` while healthy;
      * resets on a successful open or a user `close()`.

--- a/packages/durablews/tests/client.test.ts
+++ b/packages/durablews/tests/client.test.ts
@@ -565,3 +565,124 @@ describe("outbound queue", () => {
         expect(c.getState().queueLength).toBe(0);
     });
 });
+
+describe("heartbeat", () => {
+    const HURL = "ws://localhost:1242";
+    let server: WS;
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    async function open(c: WebSocketClient) {
+        const opened = c.connect();
+        await server.connected;
+        await opened;
+    }
+
+    it("sends the heartbeat message every interval while open", async () => {
+        server = new WS(HURL);
+        const c = client({
+            url: HURL,
+            reconnect: false,
+            heartbeat: { interval: 25, timeout: 60_000 }
+        });
+        await open(c);
+
+        await expect(server).toReceiveMessage("ping");
+        await expect(server).toReceiveMessage("ping");
+        c.close();
+    });
+
+    it("encodes a custom heartbeat message through the codec", async () => {
+        server = new WS(HURL);
+        const c = client({
+            url: HURL,
+            reconnect: false,
+            heartbeat: {
+                interval: 25,
+                message: { type: "hb" },
+                timeout: 60_000
+            }
+        });
+        await open(c);
+
+        await expect(server).toReceiveMessage(JSON.stringify({ type: "hb" }));
+        c.close();
+    });
+
+    it("stays open while inbound traffic answers the pings", async () => {
+        server = new WS(HURL);
+        const c = client({
+            url: HURL,
+            reconnect: false,
+            heartbeat: { interval: 20, timeout: 40 }
+        });
+        await open(c);
+
+        // Answer each ping like a live server would.
+        server.on("message", () => server.send("pong"));
+
+        await new Promise((r) => setTimeout(r, 120));
+        expect(c.state).toBe("open");
+        c.close();
+    });
+
+    it("declares a silent link dead: error + close(4408) + reconnecting", async () => {
+        server = new WS(HURL);
+        const c = client({
+            url: HURL,
+            reconnect: { baseDelay: 60_000, jitter: false },
+            heartbeat: { interval: 20, timeout: 15 }
+        });
+        const errors = vi.fn();
+        const closes = vi.fn();
+        c.on("error", errors);
+        c.on("close", closes);
+        await open(c);
+
+        // Server never responds: the deadline after the first ping must fire.
+        await vi.waitFor(() => expect(c.state).toBe("reconnecting"), {
+            timeout: 2000
+        });
+
+        expect(errors).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringMatching(/heartbeat timeout/i)
+            })
+        );
+        expect(closes).toHaveBeenCalledWith(
+            expect.objectContaining({ code: 4408 })
+        );
+        expect(c.getState().lastError).toBeInstanceOf(Error);
+        c.close();
+    });
+
+    it("does not ping when heartbeat is not configured", async () => {
+        server = new WS(HURL);
+        const c = client({ url: HURL, reconnect: false });
+        await open(c);
+
+        await new Promise((r) => setTimeout(r, 80));
+        expect(server.messages).toEqual([]);
+        c.close();
+    });
+
+    it("stops pinging after a user close()", async () => {
+        server = new WS(HURL);
+        const c = client({
+            url: HURL,
+            reconnect: false,
+            heartbeat: { interval: 20, timeout: 60_000 }
+        });
+        await open(c);
+        await expect(server).toReceiveMessage("ping");
+
+        c.close();
+        await server.closed;
+        const sentSoFar = server.messages.length;
+
+        await new Promise((r) => setTimeout(r, 60));
+        expect(server.messages.length).toBe(sentSoFar);
+    });
+});

--- a/packages/durablews/tests/heartbeat.test.ts
+++ b/packages/durablews/tests/heartbeat.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { HEARTBEAT_TIMEOUT_CODE, resolveHeartbeat } from "../src/heartbeat";
+
+describe("resolveHeartbeat", () => {
+    it("is opt-in: undefined means off", () => {
+        expect(resolveHeartbeat(undefined)).toBeNull();
+    });
+
+    it("defaults message to 'ping' and timeout to the interval", () => {
+        expect(resolveHeartbeat({ interval: 5000 })).toEqual({
+            interval: 5000,
+            message: "ping",
+            timeout: 5000
+        });
+    });
+
+    it("honors custom message and timeout", () => {
+        expect(
+            resolveHeartbeat({
+                interval: 10_000,
+                message: { type: "hb" },
+                timeout: 3000
+            })
+        ).toEqual({
+            interval: 10_000,
+            message: { type: "hb" },
+            timeout: 3000
+        });
+    });
+
+    it("uses an app-reserved close code", () => {
+        expect(HEARTBEAT_TIMEOUT_CODE).toBe(4408);
+    });
+});

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -451,7 +451,7 @@ travel in-PR):
 Order is deliberate: the codec defines what "decoded" means, so it precedes the
 middleware that operates on decoded messages.
 
-### M3 — Durability 🚧
+### M3 — Durability ✅
 
 Reconnection + exponential backoff, message queueing, idle detection. Each lands
 as its own slice with unit + integration + e2e coverage.
@@ -505,9 +505,16 @@ separate test/e2e slice.
   silently lossy. `queueLength` joins `getState()`; `send()` still throws in
   `idle`/`closing`/`closed` and (always) under `queue: false`. E2e: a message
   sent while the server is down flushes after the transparent reconnect.
-- ⬜ **Slice 3 — Idle detection / heartbeat.** Opt-in keepalive + liveness
-  timeout that forces a reconnect on a silent link. E2e: heartbeat-triggered
-  recovery.
+- ✅ **Slice 3 — Idle detection / heartbeat.** Opt-in
+  `heartbeat: { interval, message?, timeout? }` (`heartbeat.ts`; message
+  defaults to `"ping"`, timeout to the interval). While open: ping every
+  interval; *any* inbound frame counts as liveness; a silent deadline emits an
+  `error`, force-closes with app-reserved code **4408**
+  (`HEARTBEAT_TIMEOUT_CODE`, exported for `shouldReconnect` filtering), and the
+  close flows into the normal reconnect machinery (not user-initiated →
+  retryable). `lastError` widened to `Event | Error`. E2e: server goes silent
+  ("mute") → real Chromium detects the dead link via heartbeat and recovers on
+  a fresh connection.
 
 ### M4 — Adoption: docs, bindings, typed DX & 2.0 release ⬜
 


### PR DESCRIPTION
**M3 slice 3 of 3 — durability is done.** Reconnection, queueing, and now liveness checking.

## What changed
- **`heartbeat.ts`** — opt-in `heartbeat: { interval, message?, timeout? }` (message defaults to `"ping"`, timeout to the interval). **Opt-in by design** (RFC M3 decision): naive idle-reconnect kills quiet-but-healthy connections, and a ping protocol is an app-level contract the library can't assume.
- **Mechanics** — while open: ping every `interval`; *any* inbound frame counts as liveness. A silent deadline emits an `error`, records `lastError`, and force-closes with app-reserved code **4408** (`HEARTBEAT_TIMEOUT_CODE`, exported so `shouldReconnect` can filter on it). The close isn't user-initiated, so the normal reconnect machinery takes over — heartbeat death heals itself.
- Pings go straight to the socket (never queued); timers stop on close, restart on every (re)open; `lastError` widened to `Event | Error`.

## Tests
- `resolveHeartbeat` unit coverage + 6 integration tests: interval pinging, codec-encoded custom message, liveness via inbound traffic, silent-link death (`error` + 4408 + `reconnecting`), no-config-no-pings, `close()` stops pinging — **104 unit/integration green**.
- **E2e:** new server `mute` command → real Chromium detects the genuinely silent connection via heartbeat and recovers on a fresh one (**5 e2e green**).
- `typecheck:next` clean.

## Docs / RFC
Heartbeat in "what works today"; roadmap now points at M4. **RFC: slice 3 ✅ and M3 ✅.**

## With this merged, the durable-by-default story is complete
Unexpected drop → backoff reconnect. Messages while down → queued + flushed. Silent link → heartbeat-detected + recovered. All three proven in a real browser against a real server. **Next milestone: M4 — adoption** (React bindings, typed message maps, comparison docs, compat decision, 2.0 release).