### PR TITLE
feat(core): typed messages + Standard Schema validation (M4 slice 1)

### DIFF
--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -44,6 +44,44 @@ client.send({ type: "hello", message: "world" });
 client.close();
 ```
 
+## Typed (and validated) messages
+
+Pass any [Standard Schema](https://standardschema.dev) — zod, valibot,
+arktype, … — and you get **both** static types and runtime validation, with
+zero added dependencies:
+
+```ts
+import { z } from "zod";
+import { defineClient } from "durablews";
+
+const Message = z.object({ type: z.string(), body: z.string() });
+
+const client = defineClient({
+    url: "wss://example.com/socket",
+    schema: Message
+});
+
+client.on("message", (msg) => {
+    // msg is { type: string; body: string } — inferred from the schema,
+    // and every inbound message was validated at runtime.
+});
+
+client.on("error", (err) => {
+    // Invalid inbound messages arrive here as SchemaValidationError
+    // (with the schema's issues) instead of reaching your handler.
+});
+```
+
+Validation runs after the codec decodes and **before** middleware, so
+middleware and handlers only ever see trusted data.
+
+Prefer types without runtime checks? Use generics:
+
+```ts
+const client = defineClient<Incoming, Outgoing>({ url });
+// on("message") receives Incoming; send() accepts Outgoing
+```
+
 ## What works today
 
 - **Automatic reconnection, on by default** — full-jitter exponential backoff
@@ -68,6 +106,8 @@ client.close();
 - A read-only `state` and `getState()` snapshot (incl. `retryAttempt` and
   `queueLength`)
 - A pluggable wire-format codec (`codec` option; JSON by default)
+- **Typed + validated messages** via any Standard Schema (`schema` option),
+  or plain generics (`defineClient<In, Out>`)
 - A message middleware pipeline (`use()`), with an opt-in `pingpong` keepalive
 
 :::note[`connect()` and unlimited retries]
@@ -80,6 +120,7 @@ it: `Promise.race([client.connect(), timeout(10_000)])`.
 
 ## On the roadmap
 
-Framework bindings (React first), typed message maps, and channels — see the
+Framework bindings (Vue and React, co-equal), a drop-in `WebSocket`-compatible
+compat class, and channels — see the
 [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
 for the full plan and status.

--- a/packages/durablews/src/client.ts
+++ b/packages/durablews/src/client.ts
@@ -5,6 +5,7 @@ import { HEARTBEAT_TIMEOUT_CODE, resolveHeartbeat } from "@/heartbeat";
 import { defineEventBus } from "@/helpers/event-bus";
 import { runPipeline } from "@/pipeline";
 import { resolveQueue } from "@/queue";
+import { SchemaValidationError, type StandardSchemaV1 } from "@/schema";
 import type {
     ClientEventMap,
     ClientState,
@@ -272,12 +273,45 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
     }
 
     /**
-     * Runs a decoded inbound message through the middleware chain. If the chain
-     * completes, the message is emitted as `message`; a middleware that throws
-     * or rejects surfaces as an `error`.
+     * Runs a decoded — and, if a schema is configured, validated — inbound
+     * message through the middleware chain. If the chain completes, the
+     * message is emitted as `message`; a middleware that throws or rejects
+     * surfaces as an `error`. Validation precedes middleware, so middleware
+     * only ever sees trusted data; an invalid message surfaces as an `error`
+     * (`SchemaValidationError`) and never reaches middleware or `message`.
      */
     function deliver(raw: unknown) {
-        const ctx = { data: codec.decode(raw), client: api };
+        const decoded = codec.decode(raw);
+        if (config.schema === undefined) {
+            dispatchMessage(decoded);
+            return;
+        }
+        let result: ReturnType<StandardSchemaV1["~standard"]["validate"]>;
+        try {
+            result = config.schema["~standard"].validate(decoded);
+        } catch (error) {
+            bus.emit("error", toError(error));
+            return;
+        }
+        if (result instanceof Promise) {
+            result.then(handleValidated, (error: unknown) => {
+                bus.emit("error", toError(error));
+            });
+            return;
+        }
+        handleValidated(result);
+    }
+
+    function handleValidated(result: StandardSchemaV1.Result<unknown>) {
+        if (result.issues) {
+            bus.emit("error", new SchemaValidationError(result.issues));
+            return;
+        }
+        dispatchMessage(result.value);
+    }
+
+    function dispatchMessage(data: unknown) {
+        const ctx = { data, client: api };
         const emit = () => {
             bus.emit("message", ctx.data);
         };

--- a/packages/durablews/src/index.ts
+++ b/packages/durablews/src/index.ts
@@ -1,4 +1,5 @@
 import { client } from "@/client";
+import type { StandardSchemaV1 } from "@/schema";
 import type { WebSocketClient, WebSocketClientConfig } from "@/types";
 
 /**
@@ -6,12 +7,31 @@ import type { WebSocketClient, WebSocketClientConfig } from "@/types";
  *
  * Each call returns an independent client — there is no shared singleton.
  *
+ * Inbound message typing, three ways:
+ * - **Schema (recommended):** pass a [Standard Schema](https://standardschema.dev)
+ *   (zod, valibot, arktype, …) and the message type is inferred — plus every
+ *   inbound message is validated at runtime.
+ * - **Generics:** `defineClient<Incoming, Outgoing>(config)` for types without
+ *   runtime validation.
+ * - **Neither:** messages are `unknown`.
+ *
  * @example
  * ```typescript
- * const ws = defineClient({ url: "wss://example.com/socket" });
+ * const Message = z.object({ type: z.string(), body: z.string() });
+ * const ws = defineClient({ url: "wss://example.com/socket", schema: Message });
+ *
+ * ws.on("message", (msg) => {
+ *     // msg is { type: string; body: string } — validated at runtime
+ * });
  * await ws.connect();
  * ```
  */
+export function defineClient<TSchema extends StandardSchemaV1>(
+    config: WebSocketClientConfig & { readonly schema: TSchema }
+): WebSocketClient<StandardSchemaV1.InferOutput<TSchema>>;
+export function defineClient<TIn = unknown, TOut = unknown>(
+    config: WebSocketClientConfig
+): WebSocketClient<TIn, TOut>;
 export function defineClient(config: WebSocketClientConfig): WebSocketClient {
     return client(config);
 }
@@ -21,6 +41,8 @@ export { jsonCodec } from "@/codec";
 export { HEARTBEAT_TIMEOUT_CODE } from "@/heartbeat";
 export { pingpong } from "@/middleware";
 export { QUEUE_DEFAULTS } from "@/queue";
+export type { StandardSchemaV1 } from "@/schema";
+export { SchemaValidationError } from "@/schema";
 export type {
     ClientEventMap,
     ClientState,

--- a/packages/durablews/src/schema.ts
+++ b/packages/durablews/src/schema.ts
@@ -1,0 +1,72 @@
+/**
+ * The Standard Schema v1 interface (https://standardschema.dev), vendored as
+ * types-only per the spec's guidance — implementing libraries (zod, valibot,
+ * arktype, …) conform to this shape, so DurableWS can accept any of them
+ * without depending on any of them. Keeps core zero-dependency.
+ */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+    readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+}
+
+export declare namespace StandardSchemaV1 {
+    export interface Props<Input = unknown, Output = Input> {
+        readonly version: 1;
+        readonly vendor: string;
+        readonly validate: (
+            value: unknown
+        ) => Result<Output> | Promise<Result<Output>>;
+        readonly types?: Types<Input, Output> | undefined;
+    }
+
+    export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+    export interface SuccessResult<Output> {
+        readonly value: Output;
+        readonly issues?: undefined;
+    }
+
+    export interface FailureResult {
+        readonly issues: ReadonlyArray<Issue>;
+    }
+
+    export interface Issue {
+        readonly message: string;
+        readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+    }
+
+    export interface PathSegment {
+        readonly key: PropertyKey;
+    }
+
+    export interface Types<Input = unknown, Output = Input> {
+        readonly input: Input;
+        readonly output: Output;
+    }
+
+    export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+        Schema["~standard"]["types"]
+    >["input"];
+
+    export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+        Schema["~standard"]["types"]
+    >["output"];
+}
+
+/**
+ * Thrown (as an `error` event payload) when an inbound message fails the
+ * configured schema. The message is **not** emitted — handlers only ever see
+ * data that passed validation.
+ */
+export class SchemaValidationError extends Error {
+    readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
+
+    constructor(issues: ReadonlyArray<StandardSchemaV1.Issue>) {
+        super(
+            `Inbound message failed schema validation: ${issues
+                .map((issue) => issue.message)
+                .join("; ")}`
+        );
+        this.name = "SchemaValidationError";
+        this.issues = issues;
+    }
+}

--- a/packages/durablews/src/types.ts
+++ b/packages/durablews/src/types.ts
@@ -1,3 +1,5 @@
+import type { StandardSchemaV1 } from "@/schema";
+
 /**
  * Translates between application values and WebSocket wire frames.
  *
@@ -107,6 +109,15 @@ export interface WebSocketClientConfig {
      * {@link HeartbeatOptions}.
      */
     readonly heartbeat?: HeartbeatOptions;
+    /**
+     * A [Standard Schema](https://standardschema.dev) (zod, valibot, arktype,
+     * …) validating every **inbound** message after `codec.decode` and before
+     * middleware. Valid messages flow on with the schema's output value;
+     * invalid ones surface as an `error` event (`SchemaValidationError`) and
+     * are never emitted as `message`. When passed to `defineClient`, the
+     * message type is **inferred from the schema** — no generics needed.
+     */
+    readonly schema?: StandardSchemaV1;
 }
 
 /**
@@ -168,9 +179,9 @@ export interface ClientState {
  * Payload emitted on every `drop` event — a queued outbound message that will
  * never be sent.
  */
-export interface DropEvent {
+export interface DropEvent<TOut = unknown> {
     /** The original (un-encoded) value passed to `send()`. */
-    readonly data: unknown;
+    readonly data: TOut;
     /**
      * Why it was dropped: `overflow` — the queue was full and this was the
      * oldest entry; `close` — the connection ended (user `close()` or terminal
@@ -192,14 +203,15 @@ export interface ReconnectingEvent {
 /**
  * The context handed to each message middleware.
  */
-export interface MessageContext {
+export interface MessageContext<TIn = unknown> {
     /**
-     * The decoded inbound message. Middleware may reassign this to transform
-     * what later middleware — and the `message` event — receive.
+     * The decoded (and, if a schema is configured, validated) inbound message.
+     * Middleware may reassign this to transform what later middleware — and
+     * the `message` event — receive.
      */
-    data: unknown;
+    data: TIn;
     /** The client, e.g. for sending a reply from within the pipeline. */
-    readonly client: WebSocketClient;
+    readonly client: WebSocketClient<TIn>;
 }
 
 /**
@@ -210,8 +222,8 @@ export interface MessageContext {
  * calling `next()` to short-circuit (e.g. an auto-reply that shouldn't bubble).
  * May be async.
  */
-export type Middleware = (
-    ctx: MessageContext,
+export type Middleware<TIn = unknown> = (
+    ctx: MessageContext<TIn>,
     next: () => void | Promise<void>
 ) => void | Promise<void>;
 
@@ -229,11 +241,11 @@ export interface StateChange {
  * The events a client emits, mapped to their payload types. Used to give
  * `on()` precise, per-event payload typing.
  */
-export interface ClientEventMap {
+export interface ClientEventMap<TIn = unknown, TOut = unknown> {
     /** The socket opened. */
     open: undefined;
-    /** A message was received and decoded. */
-    message: unknown;
+    /** A message was received, decoded, and (if configured) validated. */
+    message: TIn;
     /** The socket closed (clean or otherwise). */
     close: CloseEvent;
     /**
@@ -246,13 +258,17 @@ export interface ClientEventMap {
     /** A reconnect attempt was scheduled (fires once per retry). */
     reconnecting: ReconnectingEvent;
     /** A queued outbound message was dropped and will never be sent. */
-    drop: DropEvent;
+    drop: DropEvent<TOut>;
 }
 
 /**
  * A resilient, zero-dependency WebSocket client.
+ *
+ * @typeParam TIn - The type of inbound messages (what `on("message")`
+ * handlers receive). Inferred from `config.schema` when one is given.
+ * @typeParam TOut - The type accepted by `send()`.
  */
-export interface WebSocketClient {
+export interface WebSocketClient<TIn = unknown, TOut = unknown> {
     /** The current connection state. */
     readonly state: ConnectionState;
 
@@ -292,7 +308,7 @@ export interface WebSocketClient {
      * Throws when the client is `idle`, `closing`, or `closed` — states where
      * no open is coming — or whenever the socket isn't open if `queue: false`.
      */
-    send(data: unknown): void;
+    send(data: TOut): void;
 
     /**
      * Closes the connection.
@@ -305,16 +321,16 @@ export interface WebSocketClient {
      * Subscribes to a client event.
      * @returns an unsubscribe function.
      */
-    on<K extends keyof ClientEventMap>(
+    on<K extends keyof ClientEventMap<TIn, TOut>>(
         event: K,
-        handler: (payload: ClientEventMap[K]) => void
+        handler: (payload: ClientEventMap<TIn, TOut>[K]) => void
     ): () => void;
 
     /**
      * Registers message middleware, run in order for each inbound message.
      * @returns the client, for chaining.
      */
-    use(middleware: Middleware): WebSocketClient;
+    use(middleware: Middleware<TIn>): WebSocketClient<TIn, TOut>;
 
     /**
      * Returns a read-only snapshot of the client's observable state.

--- a/packages/durablews/tests/client.test.ts
+++ b/packages/durablews/tests/client.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WS from "vitest-websocket-mock";
 import { client } from "../src/client";
 import { pingpong } from "../src/middleware";
+import { SchemaValidationError } from "../src/schema";
 import type { Middleware, WebSocketClient } from "../src/types";
 
 const URL = "ws://localhost:1234";
@@ -684,5 +685,147 @@ describe("heartbeat", () => {
 
         await new Promise((r) => setTimeout(r, 60));
         expect(server.messages.length).toBe(sentSoFar);
+    });
+});
+
+describe("schema validation", () => {
+    const SURL = "ws://localhost:1243";
+    let server: WS;
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    /** A minimal Standard Schema: object with a numeric `n`, else issues. */
+    const nSchema = {
+        "~standard": {
+            version: 1 as const,
+            vendor: "durablews-tests",
+            validate: (value: unknown) => {
+                const ok =
+                    typeof value === "object" &&
+                    value !== null &&
+                    typeof (value as { n?: unknown }).n === "number";
+                return ok
+                    ? { value: value as { n: number } }
+                    : { issues: [{ message: "expected { n: number }" }] };
+            }
+        }
+    };
+
+    async function open(c: WebSocketClient) {
+        const opened = c.connect();
+        await server.connected;
+        await opened;
+    }
+
+    it("emits valid messages with the schema's output value", async () => {
+        server = new WS(SURL);
+        const c = client({ url: SURL, reconnect: false, schema: nSchema });
+        const onMessage = vi.fn();
+        c.on("message", onMessage);
+        await open(c);
+
+        server.send(JSON.stringify({ n: 7 }));
+
+        expect(onMessage).toHaveBeenCalledWith({ n: 7 });
+        c.close();
+    });
+
+    it("surfaces invalid messages as SchemaValidationError, never as message", async () => {
+        server = new WS(SURL);
+        const c = client({ url: SURL, reconnect: false, schema: nSchema });
+        const onMessage = vi.fn();
+        const onError = vi.fn();
+        c.on("message", onMessage);
+        c.on("error", onError);
+        await open(c);
+
+        server.send(JSON.stringify({ wrong: true }));
+
+        expect(onMessage).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledTimes(1);
+        const error = onError.mock.calls[0][0];
+        expect(error).toBeInstanceOf(SchemaValidationError);
+        expect((error as SchemaValidationError).issues).toEqual([
+            { message: "expected { n: number }" }
+        ]);
+        c.close();
+    });
+
+    it("validation runs before middleware: invalid data never reaches it", async () => {
+        server = new WS(SURL);
+        const c = client({ url: SURL, reconnect: false, schema: nSchema });
+        const sawMiddleware = vi.fn();
+        c.use((_ctx, next) => {
+            sawMiddleware();
+            return next();
+        });
+        await open(c);
+
+        server.send(JSON.stringify({ wrong: true }));
+        expect(sawMiddleware).not.toHaveBeenCalled();
+
+        server.send(JSON.stringify({ n: 1 }));
+        expect(sawMiddleware).toHaveBeenCalledTimes(1);
+        c.close();
+    });
+
+    it("supports async validate()", async () => {
+        server = new WS(SURL);
+        const asyncSchema = {
+            "~standard": {
+                version: 1 as const,
+                vendor: "durablews-tests",
+                validate: async (value: unknown) => {
+                    await Promise.resolve();
+                    return typeof value === "number"
+                        ? { value }
+                        : { issues: [{ message: "not a number" }] };
+                }
+            }
+        };
+        const c = client({ url: SURL, reconnect: false, schema: asyncSchema });
+        const onMessage = vi.fn();
+        const onError = vi.fn();
+        c.on("message", onMessage);
+        c.on("error", onError);
+        await open(c);
+
+        server.send("42"); // JSON-decodes to the number 42
+        server.send(JSON.stringify({ nope: true }));
+        await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+
+        expect(onMessage).toHaveBeenCalledWith(42);
+        expect(onError.mock.calls[0][0]).toBeInstanceOf(SchemaValidationError);
+        c.close();
+    });
+
+    it("a validate() that throws surfaces as an error event", async () => {
+        server = new WS(SURL);
+        const throwingSchema = {
+            "~standard": {
+                version: 1 as const,
+                vendor: "durablews-tests",
+                validate: () => {
+                    throw new Error("validator exploded");
+                }
+            }
+        };
+        const c = client({
+            url: SURL,
+            reconnect: false,
+            schema: throwingSchema
+        });
+        const onError = vi.fn();
+        c.on("error", onError);
+        await open(c);
+
+        server.send("1");
+
+        expect(onError).toHaveBeenCalledWith(
+            expect.objectContaining({ message: "validator exploded" })
+        );
+        c.close();
     });
 });

--- a/packages/durablews/tests/types.test.ts
+++ b/packages/durablews/tests/types.test.ts
@@ -1,0 +1,78 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { defineClient } from "../src/index";
+import type { StandardSchemaV1 } from "../src/schema";
+import type { DropEvent } from "../src/types";
+
+const URL = "ws://localhost:9999";
+
+// A minimal Standard Schema whose output type is a chat message.
+interface Chat {
+    readonly type: "chat";
+    readonly body: string;
+}
+const chatSchema: StandardSchemaV1<unknown, Chat> = {
+    "~standard": {
+        version: 1,
+        vendor: "durablews-tests",
+        validate: (value) =>
+            typeof value === "object" && value !== null
+                ? { value: value as Chat }
+                : { issues: [{ message: "not a chat message" }] }
+    }
+};
+
+describe("typed messages (compile-time)", () => {
+    it("infers the message type from a schema", () => {
+        const ws = defineClient({ url: URL, schema: chatSchema });
+        ws.on("message", (msg) => {
+            expectTypeOf(msg).toEqualTypeOf<Chat>();
+        });
+    });
+
+    it("accepts explicit in/out generics", () => {
+        const ws = defineClient<Chat, string>({ url: URL });
+        ws.on("message", (msg) => {
+            expectTypeOf(msg).toEqualTypeOf<Chat>();
+        });
+        expectTypeOf(ws.send).parameter(0).toEqualTypeOf<string>();
+        // Compile-time only — never invoked (send() throws while idle).
+        void (() => {
+            // @ts-expect-error send only accepts the outbound type
+            ws.send({ type: "chat", body: "nope" });
+        });
+    });
+
+    it("defaults to unknown without schema or generics", () => {
+        const ws = defineClient({ url: URL });
+        ws.on("message", (msg) => {
+            expectTypeOf(msg).toEqualTypeOf<unknown>();
+        });
+        expectTypeOf(ws.send).parameter(0).toEqualTypeOf<unknown>();
+    });
+
+    it("types the drop event with the outbound type", () => {
+        const ws = defineClient<Chat, string>({ url: URL });
+        ws.on("drop", (event) => {
+            expectTypeOf(event).toEqualTypeOf<DropEvent<string>>();
+            expectTypeOf(event.data).toEqualTypeOf<string>();
+        });
+    });
+
+    it("types middleware context with the inbound type", () => {
+        const ws = defineClient<Chat>({ url: URL });
+        ws.use((ctx, next) => {
+            expectTypeOf(ctx.data).toEqualTypeOf<Chat>();
+            return next();
+        });
+    });
+
+    it("lifecycle events keep their fixed payload types", () => {
+        const ws = defineClient({ url: URL, schema: chatSchema });
+        ws.on("close", (event) => {
+            expectTypeOf(event).toEqualTypeOf<CloseEvent>();
+        });
+        ws.on("statechange", ({ current }) => {
+            expectTypeOf(current).toMatchTypeOf<string>();
+        });
+    });
+});

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -558,12 +558,18 @@ deliberate: typed maps stabilize the core surface first so bindings and the
 API reference are typed from day one; docs content lands after the surface
 stops moving; release is last.
 
-- ⬜ **Slice 1 — Typed message maps + Standard Schema validation.** The DX
-  showcase: `defineClient<MyMessages>(...)` giving `on`/`send` real
-  per-message typing (not the `on<ChatMessage>` cast of the early sketch);
-  optional schema validation at the codec seam via **Standard Schema**
-  (zod/valibot/arktype all conform). Invalid inbound → `error` event, not a
-  crash.
+- ✅ **Slice 1 — Typed messages + Standard Schema validation.** Generics
+  threaded through the surface — `WebSocketClient<TIn, TOut>`:
+  `on("message")` receives `TIn`, `send()` accepts `TOut`, `drop` carries
+  `DropEvent<TOut>`, middleware context is `MessageContext<TIn>` (defaults
+  `unknown`, fully back-compatible). `config.schema` takes any **Standard
+  Schema** (interface vendored types-only per the spec — still zero deps);
+  `defineClient({ url, schema })` **infers `TIn` from the schema**, no
+  generics needed. Validation runs decode → schema → middleware, so middleware
+  only sees trusted data; invalid inbound surfaces as an `error` event
+  (`SchemaValidationError` with the spec's issues), never as `message`; async
+  `validate` supported. Compile-time tests via `expectTypeOf` + runtime
+  validation suite.
 - ⬜ **Slice 2 — Reactive seam + Vue & React bindings.** Core
   `subscribe(listener)` over the full snapshot (per the decision above), then
   `durablews/vue` (`useWebSocket` composable: reactive state, auto-cleanup on


### PR DESCRIPTION
**M4 slice 1 of 7 — the DX showcase.** One schema gives you static types *and* runtime validation, with the library still at zero dependencies.

## What changed
- **Generics through the surface** — `WebSocketClient<TIn, TOut>`: `on("message")` → `TIn`, `send()` → `TOut`, `drop` → `DropEvent<TOut>`, middleware ctx → `MessageContext<TIn>`. Everything defaults to `unknown`, so existing untyped usage is byte-for-byte unchanged.
- **`config.schema` accepts any [Standard Schema](https://standardschema.dev)** (zod, valibot, arktype, …). The `StandardSchemaV1` interface is vendored **types-only** per the spec's own guidance — no dependency added.
- **Inference:** `defineClient({ url, schema })` infers the message type from the schema via an overload — no generics needed. `defineClient<TIn, TOut>(config)` works for types-without-validation.
- **Pipeline order:** decode → schema → middleware → `message`. Middleware and handlers only ever see validated data; invalid inbound surfaces as an `error` event carrying `SchemaValidationError` (with the spec's `issues`) and never reaches `message`. Async `validate()` supported; throwing validators surface as `error`.

## Tests (115 green)
- **Compile-time** (`expectTypeOf`): schema inference, explicit generics, unknown defaults, `drop`/middleware typing, lifecycle payloads stay fixed.
- **Runtime:** valid passthrough (with the schema's output value), invalid → `SchemaValidationError` + issues, validation-before-middleware ordering, async validate, throwing validator.
- `typecheck:next` clean on today's nightly.

## Docs / RFC
"Typed (and validated) messages" section in getting-started (zod example + generics fallback); RFC slice 1 ✅.

**Next:** slice 2 — the reactive `subscribe()` seam + `durablews/vue` and `durablews/react` bindings, then the first `2.0.0-alpha` publish.