### PR TITLE
feat(core): subscribe() seam + stable snapshots (M4 slice 2a)

### DIFF
--- a/packages/durablews/src/client.ts
+++ b/packages/durablews/src/client.ts
@@ -70,6 +70,13 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
     let retryAttempt = 0;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
+    // subscribe() listeners plus the cached getState() snapshot. The cache
+    // makes snapshots referentially stable between changes — required by
+    // React's useSyncExternalStore (a fresh object per getSnapshot() call
+    // would loop the renderer).
+    const subscribers = new Set<() => void>();
+    let snapshot: ClientState | null = null;
+
     // The in-flight connect() promise and its settlers. A single promise is
     // shared across concurrent/repeat connect() calls so the method is
     // idempotent, and it survives failed attempts while reconnection is
@@ -86,6 +93,18 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
      *
      * @returns the new state if a transition occurred, otherwise `null`.
      */
+    /**
+     * Invalidates the cached snapshot and fires subscribe() listeners. Called
+     * after every mutation of the observable state, before the corresponding
+     * bus event, so any observer reading getState() sees fresh data.
+     */
+    function notify() {
+        snapshot = null;
+        for (const listener of [...subscribers]) {
+            listener();
+        }
+    }
+
     function transition(event: ConnectionEvent): ConnectionState | null {
         const next = nextState(state, event);
         if (next === null || next === state) {
@@ -94,6 +113,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
 
         const previous = state;
         state = next;
+        notify();
         bus.emit("statechange", { previous, current: next });
         return next;
     }
@@ -158,6 +178,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
                         `Heartbeat timeout: no inbound traffic within ${heartbeat.timeout}ms of a ping`
                     );
                     lastError = failure;
+                    notify();
                     bus.emit("error", failure);
                     socket.close(HEARTBEAT_TIMEOUT_CODE, "heartbeat timeout");
                 }
@@ -172,6 +193,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
      * failure surfaces as an `error` event and flushing continues.
      */
     function flushQueue() {
+        const hadQueued = queued.length > 0;
         while (queued.length > 0 && socket && state === "open") {
             const data = queued.shift();
             try {
@@ -180,6 +202,9 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
                 bus.emit("error", toError(error));
             }
         }
+        if (hadQueued) {
+            notify();
+        }
     }
 
     /**
@@ -187,8 +212,12 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
      * (user `close()` or terminal failure). Never silently lossy.
      */
     function dropQueued() {
+        const hadQueued = queued.length > 0;
         while (queued.length > 0) {
             bus.emit("drop", { data: queued.shift(), reason: "close" });
+        }
+        if (hadQueued) {
+            notify();
         }
     }
 
@@ -206,7 +235,10 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
     }
 
     function openSocket() {
-        lastError = null;
+        if (lastError !== null) {
+            lastError = null;
+            notify();
+        }
         socket = config.protocols
             ? new WebSocket(config.url, config.protocols)
             : new WebSocket(config.url);
@@ -227,6 +259,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
 
         socket.onerror = (event: Event) => {
             lastError = event;
+            notify();
             bus.emit("error", event);
         };
 
@@ -408,6 +441,7 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
                     });
                 }
                 queued.push(data);
+                notify();
                 return;
             }
             throw new Error(
@@ -419,7 +453,10 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
             closeRequested = true;
             clearRetryTimer();
             stopHeartbeat();
-            retryAttempt = 0;
+            if (retryAttempt !== 0) {
+                retryAttempt = 0;
+                notify();
+            }
             // The user hung up: queued messages will never send. Surface them
             // now (deterministically), not when the socket finishes closing.
             dropQueued();
@@ -454,12 +491,22 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         },
 
         getState(): ClientState {
-            return Object.freeze({
-                state,
-                lastError,
-                retryAttempt,
-                queueLength: queued.length
-            });
+            if (snapshot === null) {
+                snapshot = Object.freeze({
+                    state,
+                    lastError,
+                    retryAttempt,
+                    queueLength: queued.length
+                });
+            }
+            return snapshot;
+        },
+
+        subscribe(listener: () => void) {
+            subscribers.add(listener);
+            return () => {
+                subscribers.delete(listener);
+            };
         }
     };
 

--- a/packages/durablews/src/types.ts
+++ b/packages/durablews/src/types.ts
@@ -334,8 +334,27 @@ export interface WebSocketClient<TIn = unknown, TOut = unknown> {
 
     /**
      * Returns a read-only snapshot of the client's observable state.
+     *
+     * The snapshot is **referentially stable**: repeated calls return the same
+     * frozen object until something actually changes. Together with
+     * {@link subscribe} this is exactly the `subscribe`/`getSnapshot` pair
+     * React's `useSyncExternalStore` requires, and it drives Vue/Svelte
+     * reactivity equally well.
      */
     getState(): ClientState;
+
+    /**
+     * Subscribes to **any** change of the observable snapshot — connection
+     * state, `lastError`, `retryAttempt`, or `queueLength`. Unlike
+     * `on("statechange")` (which fires only on FSM transitions), this also
+     * fires when, e.g., the queue grows on a `send()` while disconnected.
+     *
+     * The listener receives no arguments; read `getState()` for the new
+     * snapshot.
+     *
+     * @returns an unsubscribe function.
+     */
+    subscribe(listener: () => void): () => void;
 }
 
 /**

--- a/packages/durablews/tests/client.test.ts
+++ b/packages/durablews/tests/client.test.ts
@@ -829,3 +829,104 @@ describe("schema validation", () => {
         c.close();
     });
 });
+
+describe("subscribe / snapshot", () => {
+    const BURL = "ws://localhost:1244";
+    let server: WS;
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    async function open(c: WebSocketClient) {
+        const opened = c.connect();
+        await server.connected;
+        await opened;
+    }
+
+    it("getState() is referentially stable until something changes", async () => {
+        server = new WS(BURL);
+        const c = client({ url: BURL, reconnect: false });
+
+        const a = c.getState();
+        const b = c.getState();
+        expect(b).toBe(a); // same frozen object — useSyncExternalStore-safe
+
+        await open(c);
+        const after = c.getState();
+        expect(after).not.toBe(a);
+        expect(after).toBe(c.getState());
+        expect(after.state).toBe("open");
+        c.close();
+    });
+
+    it("fires on connection state changes", async () => {
+        server = new WS(BURL);
+        const c = client({ url: BURL, reconnect: false });
+        const listener = vi.fn();
+        c.subscribe(listener);
+
+        await open(c);
+        // connecting + open — at least two notifications.
+        expect(listener.mock.calls.length).toBeGreaterThanOrEqual(2);
+        c.close();
+    });
+
+    it("fires on queue growth, which is NOT an FSM transition", async () => {
+        server = new WS(BURL);
+        const c = client({ url: BURL, reconnect: false });
+        c.connect().catch(() => {});
+
+        const listener = vi.fn();
+        c.subscribe(listener);
+        const before = c.getState();
+        expect(before.queueLength).toBe(0);
+
+        c.send("queued-while-connecting");
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        const after = c.getState();
+        expect(after).not.toBe(before);
+        expect(after.queueLength).toBe(1);
+        c.close();
+    });
+
+    it("fires when a transport error records lastError", async () => {
+        server = new WS(BURL);
+        const c = client({ url: BURL, reconnect: false });
+        await open(c);
+
+        const listener = vi.fn();
+        c.subscribe(listener);
+        server.error();
+
+        expect(listener).toHaveBeenCalled();
+        expect(c.getState().lastError).not.toBeNull();
+    });
+
+    it("unsubscribe stops notifications", async () => {
+        server = new WS(BURL);
+        const c = client({ url: BURL, reconnect: false });
+        const listener = vi.fn();
+        const unsubscribe = c.subscribe(listener);
+        unsubscribe();
+
+        await open(c);
+        expect(listener).not.toHaveBeenCalled();
+        c.close();
+    });
+
+    it("listeners read a fresh snapshot from inside the notification", async () => {
+        server = new WS(BURL);
+        const c = client({ url: BURL, reconnect: false });
+        const seen: string[] = [];
+        c.subscribe(() => {
+            seen.push(c.getState().state);
+        });
+
+        await open(c);
+        expect(seen).toContain("connecting");
+        expect(seen).toContain("open");
+        c.close();
+    });
+});

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -570,8 +570,11 @@ stops moving; release is last.
   (`SchemaValidationError` with the spec's issues), never as `message`; async
   `validate` supported. Compile-time tests via `expectTypeOf` + runtime
   validation suite.
-- ⬜ **Slice 2 — Reactive seam + Vue & React bindings.** Core
-  `subscribe(listener)` over the full snapshot (per the decision above), then
+- 🚧 **Slice 2 — Reactive seam + Vue & React bindings.** *(Lands as two PRs:
+  2a the core seam — done; 2b the bindings.)* Core
+  `subscribe(listener)` over the full snapshot (per the decision above) —
+  including the `getState()` **snapshot caching** that referential-equality
+  consumers like `useSyncExternalStore` require — then
   `durablews/vue` (`useWebSocket` composable: reactive state, auto-cleanup on
   scope dispose) and `durablews/react` (`useWebSocket` via
   `useSyncExternalStore`) as subpath exports with optional peers. Each gets a


### PR DESCRIPTION
**M4 slice 2, part a of b** — the core seam the Vue/React bindings (2b) will consume.

## What changed
- **`client.subscribe(listener)`** — fires on **any** change of the observable snapshot (`state`, `lastError`, `retryAttempt`, `queueLength`). `on("statechange")` only covers FSM transitions; this also fires when, e.g., the queue grows on a `send()` while disconnected — the gap the RFC's M4 decision called out.
- **`getState()` is now referentially stable** — snapshots are cached and reused until a mutation invalidates them. This is load-bearing: React's `useSyncExternalStore` requires `getSnapshot` identity stability (a fresh object per call = infinite re-render loop).
- **`notify()`** (invalidate + fire) runs at every observable mutation, *before* the corresponding bus event, gated on actual change: FSM transitions, `lastError` set/reset (transport error, heartbeat timeout, reconnect reset), queue push/flush/drop, `retryAttempt` resets.

## Tests (121 green)
Referential stability (same frozen object until change), fires on state change / **queue growth without a transition** / `lastError`, unsubscribe stops delivery, listeners read fresh state mid-notification. `typecheck:next` clean.

**Next (2b):** `durablews/vue` + `durablews/react` subpath exports with optional peers, built on this seam, then the first `2.0.0-alpha` publish.