### PR TITLE
feat(bindings): Vue composable + React hook as subpath exports (M4 slice 2b)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -27,6 +27,13 @@ export default defineConfig({
                         { label: "Getting started", slug: "getting-started" },
                     ],
                 },
+                {
+                    label: "Frameworks",
+                    items: [
+                        { label: "Vue", slug: "frameworks/vue" },
+                        { label: "React", slug: "frameworks/react" },
+                    ],
+                },
             ],
         }),
     ],

--- a/docs/src/content/docs/frameworks/react.md
+++ b/docs/src/content/docs/frameworks/react.md
@@ -1,0 +1,128 @@
+---
+title: React
+description: The useWebSocket hook — DurableWS state in React, built on useSyncExternalStore.
+---
+
+DurableWS ships a first-class React hook in the box: `durablews/react`.
+No extra package — React is an *optional* peer dependency, so installing
+`durablews` without React never warns, and the hook only loads when you
+import it. React 18+ is required.
+
+```bash
+npm install durablews@alpha
+```
+
+## Quick start
+
+Pass a config and the hook owns the client: it connects on mount and closes
+the connection on unmount.
+
+```tsx
+import { useWebSocket } from "durablews/react";
+
+function Chat() {
+    const { state, lastMessage, send } = useWebSocket({
+        url: "wss://example.com/socket"
+    });
+
+    return (
+        <div>
+            <p>Connection: {state}</p>
+            <p>Last message: {JSON.stringify(lastMessage)}</p>
+            <button onClick={() => send({ type: "hello" })}>Say hello</button>
+        </div>
+    );
+}
+```
+
+Everything durable-by-default applies: the connection reconnects with
+full-jitter backoff, `send()` queues while disconnected and flushes on open,
+and `state` walks through `"reconnecting"` so your UI can show it.
+
+The hook is built on `useSyncExternalStore` — the client's `subscribe()` /
+`getState()` pair is exactly that contract, with referentially stable
+snapshots — so it is concurrent-rendering-safe and Strict Mode's double-effect
+mount/unmount cycle is handled.
+
+## What you get back
+
+| Property | Type | What it is |
+| --- | --- | --- |
+| `state` | `ConnectionState` | `"idle" → "connecting" → "open" → "reconnecting" → …` |
+| `lastMessage` | `TIn \| undefined` | The latest decoded (and validated) inbound message |
+| `lastError` | `Event \| Error \| null` | The most recent failure, if any |
+| `retryAttempt` | `number` | Retries used in the current disconnection episode |
+| `queueLength` | `number` | Outbound messages waiting for an open socket |
+| `send` / `connect` / `close` | functions | Proxies to the client |
+| `client` | `WebSocketClient` | The full client, for everything else (`on()`, `use()`, …) |
+
+`lastMessage` keeps only the latest message — DurableWS never accumulates
+message history. To process every message, subscribe on the client in an
+effect:
+
+```tsx
+const { client } = useWebSocket({ url });
+
+useEffect(() => {
+    // on() returns its own unsubscribe — ready-made effect cleanup.
+    return client.on("message", (msg) => {
+        // every message, not just the latest
+    });
+}, [client]);
+```
+
+## Typed messages
+
+Pass a [Standard Schema](https://standardschema.dev) (zod, valibot, arktype, …)
+and `lastMessage` is fully typed — plus every inbound message is validated at
+runtime:
+
+```tsx
+import { useWebSocket } from "durablews/react";
+import { z } from "zod";
+
+const Message = z.object({ type: z.string(), body: z.string() });
+
+function Chat() {
+    const { lastMessage } = useWebSocket({
+        url: "wss://example.com/socket",
+        schema: Message
+    });
+    // lastMessage: { type: string; body: string } | undefined
+}
+```
+
+The config is captured on first render — changing it later does not recreate
+the client, so an inline config object is fine (no `useMemo` needed).
+
+## Sharing one connection across components
+
+Pass an **existing client** instead of a config and the hook only observes
+it — it never connects or closes a client it was handed. This is the pattern
+for an app-wide connection used by many components:
+
+```tsx
+// src/ws.ts — the app owns this client
+import { defineClient } from "durablews";
+
+export const ws = defineClient({ url: "wss://example.com/socket" });
+ws.connect();
+```
+
+```tsx
+import { useWebSocket } from "durablews/react";
+import { ws } from "./ws";
+
+function StatusBadge() {
+    // Reactive views over the shared connection; unmounting this
+    // component does not close it.
+    const { state } = useWebSocket(ws);
+    return <span>{state}</span>;
+}
+```
+
+## SSR (Next.js, Remix)
+
+The hook is SSR-safe out of the box: connecting happens in an effect, and
+effects don't run on the server. The server render sees the client's initial
+snapshot (`state: "idle"`).

--- a/docs/src/content/docs/frameworks/vue.md
+++ b/docs/src/content/docs/frameworks/vue.md
@@ -1,0 +1,112 @@
+---
+title: Vue
+description: The useWebSocket composable — reactive DurableWS state for Vue 3.
+---
+
+DurableWS ships a first-class Vue 3 composable in the box: `durablews/vue`.
+No extra package — Vue is an *optional* peer dependency, so installing
+`durablews` without Vue never warns, and the composable only loads when you
+import it.
+
+```bash
+npm install durablews@alpha
+```
+
+## Quick start
+
+Pass a config and the composable owns the client: it connects immediately and
+closes the connection when the component is unmounted.
+
+```vue
+<script setup lang="ts">
+import { useWebSocket } from "durablews/vue";
+
+const { state, lastMessage, send } = useWebSocket({
+    url: "wss://example.com/socket"
+});
+</script>
+
+<template>
+    <p>Connection: {{ state }}</p>
+    <p>Last message: {{ lastMessage }}</p>
+    <button @click="send({ type: 'hello' })">Say hello</button>
+</template>
+```
+
+Everything durable-by-default applies: the connection reconnects with
+full-jitter backoff, `send()` queues while disconnected and flushes on open,
+and `state` walks through `reconnecting` so your UI can show it.
+
+## What you get back
+
+| Property | Type | What it is |
+| --- | --- | --- |
+| `state` | `ComputedRef<ConnectionState>` | `idle → connecting → open → reconnecting → …` |
+| `lastMessage` | `ShallowRef<TIn \| undefined>` | The latest decoded (and validated) inbound message |
+| `lastError` | `ComputedRef<Event \| Error \| null>` | The most recent failure, if any |
+| `retryAttempt` | `ComputedRef<number>` | Retries used in the current disconnection episode |
+| `queueLength` | `ComputedRef<number>` | Outbound messages waiting for an open socket |
+| `send` / `connect` / `close` | functions | Proxies to the client |
+| `client` | `WebSocketClient` | The full client, for everything else (`on()`, `use()`, …) |
+
+`lastMessage` keeps only the latest message — DurableWS never accumulates
+message history. To process every message, handle the event on the client:
+
+```ts
+const { client } = useWebSocket({ url });
+client.on("message", (msg) => {
+    // every message, not just the latest
+});
+```
+
+## Typed messages
+
+Pass a [Standard Schema](https://standardschema.dev) (zod, valibot, arktype, …)
+and `lastMessage` is fully typed — plus every inbound message is validated at
+runtime:
+
+```vue
+<script setup lang="ts">
+import { useWebSocket } from "durablews/vue";
+import { z } from "zod";
+
+const Message = z.object({ type: z.string(), body: z.string() });
+
+const { lastMessage } = useWebSocket({
+    url: "wss://example.com/socket",
+    schema: Message
+});
+// lastMessage: ShallowRef<{ type: string; body: string } | undefined>
+</script>
+```
+
+## Sharing one connection across components
+
+Pass an **existing client** instead of a config and the composable only
+observes it — it never connects or closes a client it was handed. This is the
+pattern for an app-wide connection used by many components:
+
+```ts
+// src/ws.ts — the app owns this client
+import { defineClient } from "durablews";
+
+export const ws = defineClient({ url: "wss://example.com/socket" });
+ws.connect();
+```
+
+```vue
+<script setup lang="ts">
+import { useWebSocket } from "durablews/vue";
+import { ws } from "@/ws";
+
+// Reactive views over the shared connection; unmounting this
+// component does not close it.
+const { state, lastMessage } = useWebSocket(ws);
+</script>
+```
+
+## SSR (Nuxt)
+
+The composable is SSR-safe: when no global `WebSocket` exists (the server
+render), auto-connect is skipped and the client connects when setup runs again
+in the browser.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -109,6 +109,10 @@ const client = defineClient<Incoming, Outgoing>({ url });
 - **Typed + validated messages** via any Standard Schema (`schema` option),
   or plain generics (`defineClient<In, Out>`)
 - A message middleware pipeline (`use()`), with an opt-in `pingpong` keepalive
+- **Framework bindings in the box** — a [Vue composable](/frameworks/vue/) and
+  a [React hook](/frameworks/react/) (`durablews/vue`, `durablews/react`) with
+  reactive connection state and automatic cleanup; the frameworks are optional
+  peers, so core installs never warn
 
 :::note[`connect()` and unlimited retries]
 `connect()` resolves on the first successful open — including when that open is
@@ -120,7 +124,7 @@ it: `Promise.race([client.connect(), timeout(10_000)])`.
 
 ## On the roadmap
 
-Framework bindings (Vue and React, co-equal), a drop-in `WebSocket`-compatible
+Outbound middleware (auth/token refresh), a drop-in `WebSocket`-compatible
 compat class, and channels — see the
 [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
 for the full plan and status.

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -16,6 +16,26 @@
                 "types": "./dist/index.d.cts",
                 "default": "./dist/index.cjs"
             }
+        },
+        "./vue": {
+            "import": {
+                "types": "./dist/vue.d.ts",
+                "default": "./dist/vue.js"
+            },
+            "require": {
+                "types": "./dist/vue.d.cts",
+                "default": "./dist/vue.cjs"
+            }
+        },
+        "./react": {
+            "import": {
+                "types": "./dist/react.d.ts",
+                "default": "./dist/react.js"
+            },
+            "require": {
+                "types": "./dist/react.d.cts",
+                "default": "./dist/react.cjs"
+            }
         }
     },
     "sideEffects": false,
@@ -32,13 +52,25 @@
         "e2e:install": "playwright install --with-deps chromium",
         "typecheck": "tsc --noEmit",
         "typecheck:next": "pnpm --package=typescript@next dlx tsc --noEmit",
-        "check:publish": "publint && attw --pack .",
+        "check:publish": "publint && attw --pack . --profile node16",
         "prepublishOnly": "pnpm build"
     },
     "author": "Nate Smith (https://imns.co/)",
     "license": "MPL-2.0",
     "engines": {
         "node": ">=22"
+    },
+    "peerDependencies": {
+        "react": ">=18",
+        "vue": ">=3.2"
+    },
+    "peerDependenciesMeta": {
+        "react": {
+            "optional": true
+        },
+        "vue": {
+            "optional": true
+        }
     },
     "repository": {
         "type": "git",
@@ -73,14 +105,20 @@
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.3",
         "@playwright/test": "^1.60.0",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.19.20",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@types/ws": "^8.18.1",
         "jsdom": "^24.0.0",
         "publint": "^0.3.21",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "tsup": "^8.5.1",
         "typescript": "^5.3.3",
         "vitest": "^1.2.2",
         "vitest-websocket-mock": "^0.3.0",
+        "vue": "^3.5.35",
         "ws": "^8.21.0"
     }
 }

--- a/packages/durablews/src/helpers/binding.ts
+++ b/packages/durablews/src/helpers/binding.ts
@@ -1,0 +1,49 @@
+import { client } from "@/client";
+import type { WebSocketClient, WebSocketClientConfig } from "@/types";
+
+/**
+ * What a framework binding accepts: either a config (the binding creates and
+ * **owns** the client — connecting it and closing it with the component) or an
+ * existing client (the binding only **observes** it — sharing one connection
+ * across many components without any binding taking over its lifecycle).
+ */
+export type UseWebSocketSource<TIn = unknown, TOut = unknown> =
+    | WebSocketClientConfig
+    | WebSocketClient<TIn, TOut>;
+
+export interface ResolvedSource<TIn = unknown, TOut = unknown> {
+    readonly client: WebSocketClient<TIn, TOut>;
+    /** Whether the binding created the client and therefore owns its lifecycle. */
+    readonly owned: boolean;
+}
+
+/**
+ * Resolves a binding source into a client plus ownership. A config produces a
+ * fresh, owned client; a passed-in client is borrowed as-is.
+ */
+export function resolveSource<TIn = unknown, TOut = unknown>(
+    source: UseWebSocketSource<TIn, TOut>
+): ResolvedSource<TIn, TOut> {
+    if (isClient(source)) {
+        return { client: source, owned: false };
+    }
+    return {
+        client: client(source) as WebSocketClient<TIn, TOut>,
+        owned: true
+    };
+}
+
+function isClient<TIn, TOut>(
+    source: UseWebSocketSource<TIn, TOut>
+): source is WebSocketClient<TIn, TOut> {
+    return typeof (source as WebSocketClient).subscribe === "function";
+}
+
+/**
+ * Whether a standard `WebSocket` global exists. Bindings skip auto-connect in
+ * its absence (e.g. SSR), so creating a component server-side never throws —
+ * the client connects when setup runs again in the browser.
+ */
+export function canConnect(): boolean {
+    return typeof WebSocket !== "undefined";
+}

--- a/packages/durablews/src/react.ts
+++ b/packages/durablews/src/react.ts
@@ -1,0 +1,124 @@
+/**
+ * React bindings for durablews — `import { useWebSocket } from "durablews/react"`.
+ *
+ * Requires React 18+ (an optional peer dependency: installing durablews
+ * without React never warns; this module only loads when imported).
+ */
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { resolveSource, type UseWebSocketSource } from "@/helpers/binding";
+import type { StandardSchemaV1 } from "@/schema";
+import type {
+    ConnectionState,
+    WebSocketClient,
+    WebSocketClientConfig
+} from "@/types";
+
+/**
+ * What {@link useWebSocket} returns: the client itself plus its observable
+ * state as plain render-ready values.
+ */
+export interface UseWebSocketReturn<TIn = unknown, TOut = unknown> {
+    /** The underlying client, for everything beyond the hook's surface. */
+    readonly client: WebSocketClient<TIn, TOut>;
+    /** The connection state. */
+    readonly state: ConnectionState;
+    /** The most recent failure, if any. */
+    readonly lastError: Event | Error | null;
+    /** Retries used in the current disconnection episode. */
+    readonly retryAttempt: number;
+    /** Messages currently waiting in the outbound queue. */
+    readonly queueLength: number;
+    /**
+     * The most recent inbound message (decoded and, if a schema is configured,
+     * validated). `undefined` until the first message arrives. Only the latest
+     * message is retained — handle the `message` event on {@link client} to
+     * process every message.
+     */
+    readonly lastMessage: TIn | undefined;
+    /** Sends data (queueing while disconnected, per the client's config). */
+    readonly send: (data: TOut) => void;
+    /** Opens the connection. See `WebSocketClient.connect`. */
+    readonly connect: () => Promise<void>;
+    /** Closes the connection. */
+    readonly close: (code?: number, reason?: string) => void;
+}
+
+/**
+ * A hook exposing a durablews client as React state, built on
+ * `useSyncExternalStore` (the client's `subscribe`/`getState` pair is exactly
+ * that contract, with referentially stable snapshots).
+ *
+ * Pass a **config** and the hook owns the client: it connects in an effect
+ * (SSR-safe — effects don't run on the server) and closes the connection on
+ * unmount. The config is captured on first render; changing it later does not
+ * recreate the client. Pass an **existing client** (e.g. an app-wide singleton
+ * shared by many components) and the hook only observes it — it never connects
+ * or closes a client it was handed.
+ *
+ * @example
+ * ```tsx
+ * import { useWebSocket } from "durablews/react";
+ *
+ * function Status() {
+ *     const { state, lastMessage, send } = useWebSocket({
+ *         url: "wss://example.com/socket"
+ *     });
+ *     return (
+ *         <button onClick={() => send({ type: "hello" })}>
+ *             {state} — last: {JSON.stringify(lastMessage)}
+ *         </button>
+ *     );
+ * }
+ * ```
+ */
+export function useWebSocket<TSchema extends StandardSchemaV1>(
+    source: WebSocketClientConfig & { readonly schema: TSchema }
+): UseWebSocketReturn<StandardSchemaV1.InferOutput<TSchema>>;
+export function useWebSocket<TIn = unknown, TOut = unknown>(
+    source: UseWebSocketSource<TIn, TOut>
+): UseWebSocketReturn<TIn, TOut>;
+export function useWebSocket(source: UseWebSocketSource): UseWebSocketReturn {
+    // Resolve exactly once per hook instance (state initializers run only on
+    // first render), so re-renders never spawn extra clients.
+    const [{ client: ws, owned }] = useState(() => resolveSource(source));
+
+    const snapshot = useSyncExternalStore(
+        ws.subscribe,
+        ws.getState,
+        ws.getState
+    );
+
+    const [lastMessage, setLastMessage] = useState<unknown>(undefined);
+    useEffect(
+        // The updater form guards against function-valued messages, which
+        // setState would otherwise invoke instead of store.
+        () => ws.on("message", (msg) => setLastMessage(() => msg)),
+        [ws]
+    );
+
+    useEffect(() => {
+        if (!owned) {
+            return;
+        }
+        // Terminal failures surface via the `error`/`close` events; swallow
+        // the rejection so fire-and-forget auto-connect never goes unhandled.
+        ws.connect().catch(() => {});
+        // Strict Mode runs this effect twice: close() then connect() again is
+        // a legal closed → fresh-episode sequence, so the double-run is safe.
+        return () => ws.close();
+    }, [ws, owned]);
+
+    return {
+        client: ws,
+        state: snapshot.state,
+        lastError: snapshot.lastError,
+        retryAttempt: snapshot.retryAttempt,
+        queueLength: snapshot.queueLength,
+        lastMessage,
+        send: ws.send,
+        connect: ws.connect,
+        close: ws.close
+    };
+}
+
+export type { UseWebSocketSource } from "@/helpers/binding";

--- a/packages/durablews/src/vue.ts
+++ b/packages/durablews/src/vue.ts
@@ -1,0 +1,130 @@
+/**
+ * Vue bindings for durablews — `import { useWebSocket } from "durablews/vue"`.
+ *
+ * Requires Vue 3 (an optional peer dependency: installing durablews without
+ * Vue never warns; this module only loads when imported).
+ */
+import {
+    type ComputedRef,
+    computed,
+    getCurrentScope,
+    onScopeDispose,
+    type ShallowRef,
+    shallowRef
+} from "vue";
+import {
+    canConnect,
+    resolveSource,
+    type UseWebSocketSource
+} from "@/helpers/binding";
+import type { StandardSchemaV1 } from "@/schema";
+import type {
+    ConnectionState,
+    WebSocketClient,
+    WebSocketClientConfig
+} from "@/types";
+
+/**
+ * What {@link useWebSocket} returns: the client itself plus reactive views of
+ * its observable state.
+ */
+export interface UseWebSocketReturn<TIn = unknown, TOut = unknown> {
+    /** The underlying client, for everything beyond the reactive surface. */
+    readonly client: WebSocketClient<TIn, TOut>;
+    /** The connection state, as a reactive ref. */
+    readonly state: ComputedRef<ConnectionState>;
+    /** The most recent failure, if any. */
+    readonly lastError: ComputedRef<Event | Error | null>;
+    /** Retries used in the current disconnection episode. */
+    readonly retryAttempt: ComputedRef<number>;
+    /** Messages currently waiting in the outbound queue. */
+    readonly queueLength: ComputedRef<number>;
+    /**
+     * The most recent inbound message (decoded and, if a schema is configured,
+     * validated). `undefined` until the first message arrives. Only the latest
+     * message is retained — handle the `message` event on {@link client} to
+     * process every message.
+     */
+    readonly lastMessage: Readonly<ShallowRef<TIn | undefined>>;
+    /** Sends data (queueing while disconnected, per the client's config). */
+    readonly send: (data: TOut) => void;
+    /** Opens the connection. See `WebSocketClient.connect`. */
+    readonly connect: () => Promise<void>;
+    /** Closes the connection. */
+    readonly close: (code?: number, reason?: string) => void;
+}
+
+/**
+ * A composable exposing a durablews client as reactive state.
+ *
+ * Pass a **config** and the composable owns the client: it connects
+ * immediately (skipped during SSR — the browser run connects) and closes the
+ * connection when the component's scope is disposed. Pass an **existing
+ * client** (e.g. an app-wide singleton shared by many components) and the
+ * composable only observes it — it never connects or closes a client it was
+ * handed.
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { useWebSocket } from "durablews/vue";
+ *
+ * const { state, lastMessage, send } = useWebSocket({
+ *     url: "wss://example.com/socket"
+ * });
+ * </script>
+ *
+ * <template>
+ *     <p>{{ state }} — last: {{ lastMessage }}</p>
+ *     <button @click="send({ type: 'hello' })">Say hello</button>
+ * </template>
+ * ```
+ */
+export function useWebSocket<TSchema extends StandardSchemaV1>(
+    source: WebSocketClientConfig & { readonly schema: TSchema }
+): UseWebSocketReturn<StandardSchemaV1.InferOutput<TSchema>>;
+export function useWebSocket<TIn = unknown, TOut = unknown>(
+    source: UseWebSocketSource<TIn, TOut>
+): UseWebSocketReturn<TIn, TOut>;
+export function useWebSocket(source: UseWebSocketSource): UseWebSocketReturn {
+    const { client: ws, owned } = resolveSource(source);
+
+    const snapshot = shallowRef(ws.getState());
+    const stopSnapshot = ws.subscribe(() => {
+        snapshot.value = ws.getState();
+    });
+    const lastMessage = shallowRef<unknown>(undefined);
+    const offMessage = ws.on("message", (msg) => {
+        lastMessage.value = msg;
+    });
+
+    if (owned && canConnect()) {
+        // Terminal failures surface via the `error`/`close` events; swallow
+        // the rejection so fire-and-forget auto-connect never goes unhandled.
+        ws.connect().catch(() => {});
+    }
+
+    if (getCurrentScope()) {
+        onScopeDispose(() => {
+            stopSnapshot();
+            offMessage();
+            if (owned) {
+                ws.close();
+            }
+        });
+    }
+
+    return {
+        client: ws,
+        state: computed(() => snapshot.value.state),
+        lastError: computed(() => snapshot.value.lastError),
+        retryAttempt: computed(() => snapshot.value.retryAttempt),
+        queueLength: computed(() => snapshot.value.queueLength),
+        lastMessage,
+        send: ws.send,
+        connect: ws.connect,
+        close: ws.close
+    };
+}
+
+export type { UseWebSocketSource } from "@/helpers/binding";

--- a/packages/durablews/tests/react.test.ts
+++ b/packages/durablews/tests/react.test.ts
@@ -1,0 +1,157 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    expectTypeOf,
+    it
+} from "vitest";
+import WS from "vitest-websocket-mock";
+import { client } from "../src/client";
+import { useWebSocket } from "../src/react";
+import type { StandardSchemaV1 } from "../src/schema";
+
+// React requires this flag for act() in non-react-dom/test-utils environments.
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const URL = "ws://localhost:1234";
+
+describe("react useWebSocket", () => {
+    let server: WS;
+
+    beforeEach(() => {
+        server = new WS(URL);
+    });
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    it("owns a client created from a config: auto-connects and tracks state", async () => {
+        const { result, unmount } = renderHook(() =>
+            useWebSocket({ url: URL, reconnect: false })
+        );
+
+        expect(result.current.state).toBe("connecting");
+        await act(async () => {
+            await server.connected;
+        });
+        await waitFor(() => {
+            expect(result.current.state).toBe("open");
+        });
+        unmount();
+    });
+
+    it("exposes the latest inbound message", async () => {
+        const { result, unmount } = renderHook(() =>
+            useWebSocket({ url: URL, reconnect: false })
+        );
+        await act(async () => {
+            await server.connected;
+        });
+
+        expect(result.current.lastMessage).toBeUndefined();
+        await act(async () => {
+            server.send(JSON.stringify({ type: "chat", body: "hi" }));
+        });
+        await waitFor(() => {
+            expect(result.current.lastMessage).toEqual({
+                type: "chat",
+                body: "hi"
+            });
+        });
+        unmount();
+    });
+
+    it("send() proxies to the client (queueing while connecting)", async () => {
+        const { result, unmount } = renderHook(() =>
+            useWebSocket({ url: URL, reconnect: false })
+        );
+
+        // Still connecting: the message queues and the snapshot reflects it.
+        act(() => {
+            result.current.send("early");
+        });
+        expect(result.current.queueLength).toBe(1);
+
+        await act(async () => {
+            await server.connected;
+        });
+        await expect(server).toReceiveMessage("early");
+        await waitFor(() => {
+            expect(result.current.queueLength).toBe(0);
+        });
+        unmount();
+    });
+
+    it("keeps the same client across re-renders", async () => {
+        const { result, rerender, unmount } = renderHook(() =>
+            useWebSocket({ url: URL, reconnect: false })
+        );
+        const first = result.current.client;
+        rerender();
+        expect(result.current.client).toBe(first);
+        await act(async () => {
+            await server.connected;
+        });
+        unmount();
+    });
+
+    it("closes an owned client on unmount", async () => {
+        const { result, unmount } = renderHook(() =>
+            useWebSocket({ url: URL, reconnect: false })
+        );
+        await act(async () => {
+            await server.connected;
+        });
+        await waitFor(() => {
+            expect(result.current.state).toBe("open");
+        });
+
+        const owned = result.current.client;
+        unmount();
+        await waitFor(() => {
+            expect(owned.state).toBe("closed");
+        });
+    });
+
+    it("borrows an existing client: never connects or closes it", async () => {
+        const core = client({ url: URL, reconnect: false });
+        const opened = core.connect();
+        await act(async () => {
+            await server.connected;
+        });
+        await opened;
+
+        const { result, unmount } = renderHook(() => useWebSocket(core));
+        expect(result.current.client).toBe(core);
+        expect(result.current.state).toBe("open");
+
+        unmount();
+        expect(core.state).toBe("open");
+    });
+
+    it("infers the message type from a schema (compile-time)", async () => {
+        interface Chat {
+            readonly body: string;
+        }
+        const chatSchema: StandardSchemaV1<unknown, Chat> = {
+            "~standard": {
+                version: 1,
+                vendor: "durablews-tests",
+                validate: (value) => ({ value: value as Chat })
+            }
+        };
+        const { result, unmount } = renderHook(() =>
+            useWebSocket({ url: URL, reconnect: false, schema: chatSchema })
+        );
+        expectTypeOf(result.current.lastMessage).toEqualTypeOf<
+            Chat | undefined
+        >();
+        await act(async () => {
+            await server.connected;
+        });
+        unmount();
+    });
+});

--- a/packages/durablews/tests/vue.test.ts
+++ b/packages/durablews/tests/vue.test.ts
@@ -1,0 +1,144 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    expectTypeOf,
+    it,
+    vi
+} from "vitest";
+import WS from "vitest-websocket-mock";
+import { type ComputedRef, type EffectScope, effectScope } from "vue";
+import { client } from "../src/client";
+import type { StandardSchemaV1 } from "../src/schema";
+import { useWebSocket } from "../src/vue";
+
+const URL = "ws://localhost:1234";
+
+describe("vue useWebSocket", () => {
+    let server: WS;
+    let scope: EffectScope;
+
+    beforeEach(() => {
+        server = new WS(URL);
+        scope = effectScope();
+    });
+
+    afterEach(() => {
+        scope.stop();
+        WS.clean();
+    });
+
+    function inScope<T>(fn: () => T): T {
+        const result = scope.run(fn);
+        if (result === undefined) {
+            throw new Error("scope.run returned undefined");
+        }
+        return result;
+    }
+
+    it("owns a client created from a config: auto-connects and tracks state reactively", async () => {
+        const ws = inScope(() => useWebSocket({ url: URL, reconnect: false }));
+
+        expect(ws.state.value).toBe("connecting");
+        await server.connected;
+        await vi.waitFor(() => {
+            expect(ws.state.value).toBe("open");
+        });
+    });
+
+    it("exposes the latest inbound message as a ref", async () => {
+        const ws = inScope(() => useWebSocket({ url: URL, reconnect: false }));
+        await server.connected;
+
+        expect(ws.lastMessage.value).toBeUndefined();
+        server.send(JSON.stringify({ type: "chat", body: "hi" }));
+        await vi.waitFor(() => {
+            expect(ws.lastMessage.value).toEqual({ type: "chat", body: "hi" });
+        });
+    });
+
+    it("send() proxies to the client (queueing while connecting)", async () => {
+        const ws = inScope(() => useWebSocket({ url: URL, reconnect: false }));
+
+        // Still connecting: the message queues and the ref reflects it.
+        ws.send("early");
+        expect(ws.queueLength.value).toBe(1);
+
+        await server.connected;
+        await expect(server).toReceiveMessage("early");
+        await vi.waitFor(() => {
+            expect(ws.queueLength.value).toBe(0);
+        });
+
+        ws.send("late");
+        await expect(server).toReceiveMessage("late");
+    });
+
+    it("closes an owned client when the scope is disposed", async () => {
+        const ws = inScope(() => useWebSocket({ url: URL, reconnect: false }));
+        await server.connected;
+        await vi.waitFor(() => {
+            expect(ws.state.value).toBe("open");
+        });
+
+        scope.stop();
+        await vi.waitFor(() => {
+            expect(ws.client.state).toBe("closed");
+        });
+    });
+
+    it("borrows an existing client: never connects or closes it", async () => {
+        const core = client({ url: URL, reconnect: false });
+        const ws = inScope(() => useWebSocket(core));
+
+        // Not auto-connected.
+        expect(ws.client).toBe(core);
+        expect(ws.state.value).toBe("idle");
+
+        // Reactive once the app connects it.
+        const opened = core.connect();
+        await server.connected;
+        await opened;
+        expect(ws.state.value).toBe("open");
+
+        // Disposal detaches the binding but leaves the client running.
+        scope.stop();
+        expect(core.state).toBe("open");
+    });
+
+    it("stops tracking after disposal", async () => {
+        const core = client({ url: URL, reconnect: false });
+        const ws = inScope(() => useWebSocket(core));
+        scope.stop();
+
+        const opened = core.connect();
+        await server.connected;
+        await opened;
+        expect(ws.state.value).toBe("idle");
+
+        server.send(JSON.stringify("ignored"));
+        await vi.waitFor(() => {
+            expect(core.state).toBe("open");
+        });
+        expect(ws.lastMessage.value).toBeUndefined();
+    });
+
+    it("infers the message type from a schema (compile-time)", () => {
+        interface Chat {
+            readonly body: string;
+        }
+        const chatSchema: StandardSchemaV1<unknown, Chat> = {
+            "~standard": {
+                version: 1,
+                vendor: "durablews-tests",
+                validate: (value) => ({ value: value as Chat })
+            }
+        };
+        const ws = inScope(() =>
+            useWebSocket({ url: URL, reconnect: false, schema: chatSchema })
+        );
+        expectTypeOf(ws.lastMessage.value).toEqualTypeOf<Chat | undefined>();
+        expectTypeOf(ws.state).toMatchTypeOf<ComputedRef<string>>();
+    });
+});

--- a/packages/durablews/tsup.config.ts
+++ b/packages/durablews/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-    entry: ["src/index.ts"],
+    entry: ["src/index.ts", "src/vue.ts", "src/react.ts"],
     format: ["esm", "cjs"],
     dts: true,
     clean: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,18 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
         specifier: ^22.19.20
         version: 22.19.20
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -57,6 +66,12 @@ importers:
       publint:
         specifier: ^0.3.21
         version: 0.3.21
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)
@@ -69,6 +84,9 @@ importers:
       vitest-websocket-mock:
         specifier: ^0.3.0
         version: 0.3.0(vitest@1.6.1(@types/node@22.19.20)(jsdom@24.1.3))
+      vue:
+        specifier: ^3.5.35
+        version: 3.5.35(typescript@5.9.3)
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -128,6 +146,10 @@ packages:
 
   '@astrojs/underscore-redirects@1.0.0':
     resolution: {integrity: sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -1622,6 +1644,28 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1661,6 +1705,14 @@ packages:
   '@types/node@24.13.1':
     resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -1690,6 +1742,35 @@ packages:
 
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  '@vue/compiler-core@3.5.35':
+    resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
+
+  '@vue/compiler-dom@3.5.35':
+    resolution: {integrity: sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==}
+
+  '@vue/compiler-sfc@3.5.35':
+    resolution: {integrity: sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==}
+
+  '@vue/compiler-ssr@3.5.35':
+    resolution: {integrity: sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==}
+
+  '@vue/reactivity@3.5.35':
+    resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
+
+  '@vue/runtime-core@3.5.35':
+    resolution: {integrity: sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==}
+
+  '@vue/runtime-dom@3.5.35':
+    resolution: {integrity: sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==}
+
+  '@vue/server-renderer@3.5.35':
+    resolution: {integrity: sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==}
+    peerDependencies:
+      vue: 3.5.35
+
+  '@vue/shared@3.5.35':
+    resolution: {integrity: sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1755,6 +1836,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1995,6 +2079,9 @@ packages:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -2069,6 +2156,9 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -2109,6 +2199,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   environment@1.1.0:
@@ -2542,6 +2636,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -2665,6 +2762,10 @@ packages:
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3139,6 +3240,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3178,8 +3283,20 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -3314,6 +3431,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.8.2:
     resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
@@ -3829,6 +3949,14 @@ packages:
       jsdom:
         optional: true
 
+  vue@3.5.35:
+    resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -4171,6 +4299,12 @@ snapshots:
       - supports-color
 
   '@astrojs/underscore-redirects@1.0.0': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -5214,6 +5348,29 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -5255,6 +5412,14 @@ snapshots:
   '@types/node@24.13.1':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/sax@1.2.7':
     dependencies:
@@ -5298,6 +5463,60 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@vue/compiler-core@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.35
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.35':
+    dependencies:
+      '@vue/compiler-core': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/compiler-sfc@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.35
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.15
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.35':
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/reactivity@3.5.35':
+    dependencies:
+      '@vue/shared': 3.5.35
+
+  '@vue/runtime-core@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/runtime-dom@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/runtime-core': 3.5.35
+      '@vue/shared': 3.5.35
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      vue: 3.5.35(typescript@5.9.3)
+
+  '@vue/shared@3.5.35': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -5347,6 +5566,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -5663,6 +5886,8 @@ snapshots:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
 
+  csstype@3.2.3: {}
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -5716,6 +5941,8 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dom-accessibility-api@0.5.16: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -5756,6 +5983,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   environment@1.1.0: {}
 
@@ -6437,6 +6666,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-tokens@4.0.0: {}
+
   js-tokens@9.0.1: {}
 
   js-yaml@3.14.2:
@@ -6555,6 +6786,8 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -7308,6 +7541,12 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -7344,7 +7583,16 @@ snapshots:
 
   radix3@1.1.2: {}
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
   react-is@18.3.1: {}
+
+  react@19.2.7: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -7578,6 +7826,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
 
   semver@7.8.2: {}
 
@@ -8040,6 +8290,16 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vue@3.5.35(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-sfc': 3.5.35
+      '@vue/runtime-dom': 3.5.35
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@5.9.3))
+      '@vue/shared': 3.5.35
+    optionalDependencies:
+      typescript: 5.9.3
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -570,15 +570,21 @@ stops moving; release is last.
   (`SchemaValidationError` with the spec's issues), never as `message`; async
   `validate` supported. Compile-time tests via `expectTypeOf` + runtime
   validation suite.
-- 🚧 **Slice 2 — Reactive seam + Vue & React bindings.** *(Lands as two PRs:
-  2a the core seam — done; 2b the bindings.)* Core
+- ✅ **Slice 2 — Reactive seam + Vue & React bindings.** *(Landed as two PRs:
+  2a the core seam; 2b the bindings.)* Core
   `subscribe(listener)` over the full snapshot (per the decision above) —
   including the `getState()` **snapshot caching** that referential-equality
   consumers like `useSyncExternalStore` require — then
   `durablews/vue` (`useWebSocket` composable: reactive state, auto-cleanup on
   scope dispose) and `durablews/react` (`useWebSocket` via
-  `useSyncExternalStore`) as subpath exports with optional peers. Each gets a
-  docs page written in its community's idiom. First `2.0.0-alpha` publish with
+  `useSyncExternalStore`) as subpath exports with optional peers (`vue >=3.2`,
+  `react >=18`). Shared semantics: pass a *config* and the binding owns the
+  client (auto-connect, SSR-safe, closed on dispose/unmount); pass an
+  *existing client* and the binding only observes it — the app-singleton
+  sharing pattern. Both expose the snapshot fields plus a bounded
+  `lastMessage` (latest message only — core still never accumulates history)
+  and infer types from `config.schema`. Each has a docs page in its
+  community's idiom (composables / hooks). First `2.0.0-alpha` publish with
   bindings included.
 - ⬜ **Slice 3 — Outbound middleware.** Settles the §9 shape question
   (mirrored onion vs. `onSend` hook) with auth/token-refresh as the driving


### PR DESCRIPTION
## Summary

M4 slice 2b — the framework bindings, built on the `subscribe()`/stable-`getState()` seam from #25. `durablews/vue` and `durablews/react` ship **in the box** as subpath exports with optional peers, per the settled M4 decision (one package, one npm page, versions can never drift).

## The API (shared semantics, per-framework idiom)

Both bindings expose one function, `useWebSocket(source)`:

- **Pass a config** → the binding **owns** the client: connects immediately (SSR-safe — skipped when no `WebSocket` global / run in an effect), closes it on scope dispose (Vue) / unmount (React).
- **Pass an existing client** → the binding only **observes**: never connects or closes a client it was handed. This is the app-singleton pattern for sharing one connection across components.

Returned surface (same shape in both, in each framework's reactive currency): `state`, `lastError`, `retryAttempt`, `queueLength`, `lastMessage`, plus `send`/`connect`/`close` and the `client` itself. `lastMessage` holds the **latest message only** — core's no-message-history rule still holds. Schema-based type inference works exactly like `defineClient`.

- **Vue**: `shallowRef` + `computed` over the subscribe seam, cleanup via `onScopeDispose`. Vue `>=3.2`, optional peer.
- **React**: `useSyncExternalStore` (the exact contract 2a's stable snapshots were built for), Strict-Mode-safe effect lifecycle. React `>=18`, optional peer.

## Packaging

- tsup multi-entry (`index`, `vue`, `react`); `./vue` and `./react` in the exports map with full ESM/CJS + types.
- `vue`/`react` as `peerDependencies` with `peerDependenciesMeta.optional` — core installs never warn.
- attw moved to the `node16` profile: node10 resolution predates `exports` maps and we require Node ≥22, so adding legacy `typesVersions` cruft for it would be noise. All node16/bundler resolutions 🟢.

## Tests & docs

- 14 new tests (`vue.test.ts`, `react.test.ts`): ownership semantics (owned closes on dispose, borrowed never touched), reactivity, queue visibility, detach-after-dispose, compile-time schema inference. **135 total**, zero React `act()` warnings.
- Docs: new **Frameworks** sidebar group — Vue page written in composables idiom, React page in hooks idiom (incl. the shared-singleton pattern and SSR notes); getting-started updated.
- RFC §8: slice 2 marked ✅.

Next: first `2.0.0-alpha` publish (needs your npm login or an `NPM_TOKEN` decision), then slice 3 (outbound middleware).