### PR TITLE
chore(release): changesets npm publish workflow + alpha pre mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,9 @@
+{
+    "mode": "pre",
+    "tag": "alpha",
+    "initialVersions": {
+        "docs": "0.0.0",
+        "durablews": "2.0.0-alpha.0"
+    },
+    "changesets": ["young-llamas-launch"]
+}

--- a/.changeset/young-llamas-launch.md
+++ b/.changeset/young-llamas-launch.md
@@ -1,0 +1,31 @@
+---
+"durablews": minor
+---
+
+First public v2 alpha. A ground-up rewrite of the client around an explicit
+connection state machine — durable by default, zero dependencies, built on the
+standard global `WebSocket` (browsers, Node ≥ 22, Deno, Bun, edge).
+
+- **Automatic reconnection, on by default** — full-jitter exponential backoff,
+  unlimited retries, `shouldReconnect` veto, `reconnecting` events.
+- **Message queueing while disconnected, on by default** — bounded,
+  drop-oldest, flushed in order on open; every dropped message fires a `drop`
+  event.
+- **Opt-in heartbeat / idle detection** — dead links are closed (code `4408`)
+  and recovered through the normal reconnect machinery.
+- **Typed + validated messages** — pass any Standard Schema (zod, valibot,
+  arktype, …) and message types are inferred and runtime-validated; or use
+  plain generics.
+- **Middleware, inbound and outbound** — `use()` onion pipeline; outbound runs
+  at transmission time, async-capable with strict send-order preservation
+  (auth/token-refresh ready).
+- **Framework bindings in the box** — `durablews/vue` (composable) and
+  `durablews/react` (hook via `useSyncExternalStore`), with the frameworks as
+  optional peers.
+- **Pluggable codec** — JSON by default, swap in anything.
+- Promise-based `connect()`, standard event vocabulary (`open` / `message` /
+  `close` / `error` / `statechange`), observable state snapshots with
+  `subscribe()` / `getState()`.
+
+Breaking: the v1 store API (`defineStore`, `dispatch`, actions/reducers) is
+removed; `defineClient` no longer returns a shared singleton.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency: release-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write # npm provenance
+
+jobs:
+  release:
+    name: Version or publish
+    runs-on: ubuntu-latest
+    # Gated until the NPM_TOKEN secret exists (mirrors DOCS_DEPLOY_ENABLED):
+    # flip the NPM_PUBLISH_ENABLED repo variable to "true" to activate.
+    if: github.repository == 'imnsco/DurableWS' && vars.NPM_PUBLISH_ENABLED == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      # With pending changesets: opens/updates the "Version Packages" PR.
+      # Without (i.e. the Version PR just merged): builds and publishes to npm
+      # under the dist-tag changesets derives from pre mode ("alpha").
+      - name: Version PR or publish
+        uses: changesets/action@v1
+        with:
+          version: pnpm release:version
+          publish: pnpm release:publish
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary

The automated publish path, ready to activate when the npm token is in place.

- **`.github/workflows/release.yml`** — on every push to `main`: while changesets are pending, the changesets action opens/updates a **"Version Packages" PR**; when that PR merges, the same workflow **builds and publishes to npm** (with provenance) under the dist-tag changesets derives from pre mode — `alpha`. Gated on a `NPM_PUBLISH_ENABLED` repo variable until the secret exists, same pattern as `DOCS_DEPLOY_ENABLED`.
- **Alpha pre mode entered** (`.changeset/pre.json`) — every release while in pre mode versions as `2.0.0-alpha.N`. Verified locally: the pending changeset versions to `2.0.0-alpha.1`. (We exit pre mode at M4 slice 7 for the real 2.0.0.)
- **First changeset** — the v2 alpha release notes covering everything shipped since the rewrite began.

## To activate (your side, ~3 minutes)

1. npm → Access Tokens → **Generate granular access token**: read/write, scoped to the `durablews` package only, pick an expiry. (Granular tokens bypass OTP for CI publish.)
2. GitHub repo → Settings → Secrets and variables → Actions → **New repository secret**: `NPM_TOKEN`.
3. Same page, Variables tab → **New repository variable**: `NPM_PUBLISH_ENABLED` = `true`.
4. Settings → Actions → General → Workflow permissions: ensure **"Allow GitHub Actions to create and approve pull requests"** is checked (the action needs it to open the Version PR).

Then the next push to `main` opens the Version PR; merging it publishes `durablews@2.0.0-alpha.1` to the `alpha` dist-tag. No further manual steps, ever.