### PR TITLE
docs: M4 slice 4 — guides, API reference, comparison page, llms.txt

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -25,6 +25,19 @@ export default defineConfig({
                     label: "Start here",
                     items: [
                         { label: "Getting started", slug: "getting-started" },
+                        { label: "Why DurableWS?", slug: "comparison" },
+                    ],
+                },
+                {
+                    label: "Guides",
+                    items: [
+                        { label: "Durability tuning", slug: "guides/durability" },
+                        { label: "Middleware", slug: "guides/middleware" },
+                        { label: "Codecs", slug: "guides/codecs" },
+                        {
+                            label: "Migrating from v1",
+                            slug: "guides/migrating-from-v1",
+                        },
                     ],
                 },
                 {
@@ -33,6 +46,10 @@ export default defineConfig({
                         { label: "Vue", slug: "frameworks/vue" },
                         { label: "React", slug: "frameworks/react" },
                     ],
+                },
+                {
+                    label: "Reference",
+                    items: [{ label: "API reference", slug: "reference/api" }],
                 },
             ],
         }),

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,39 @@
+# DurableWS
+
+> A resilient, zero-dependency WebSocket client for TypeScript — durable by
+> default. Automatic reconnection (full-jitter exponential backoff), bounded
+> message queueing with observable drops, opt-in heartbeat/idle detection,
+> typed + Standard-Schema-validated messages, middleware in both directions
+> (auth-ready), a pluggable codec, and Vue/React bindings in the box. Built on
+> the standard global WebSocket: browsers, Node >= 22, Deno, Bun, edge.
+
+Install: `npm install durablews@alpha` (v2 is in alpha; the 1.x release on npm
+predates the rewrite and should not be used).
+
+Quick start:
+
+```ts
+import { defineClient } from "durablews";
+
+const client = defineClient({ url: "wss://example.com/socket" });
+client.on("message", (msg) => console.log(msg));
+await client.connect();
+client.send({ type: "hello" });
+```
+
+## Docs
+
+- [Getting started](https://durablews.imns.co/getting-started/): install, quick start, typed messages, what works today
+- [API reference](https://durablews.imns.co/reference/api/): every export, config option, client member, and event
+- [Durability tuning](https://durablews.imns.co/guides/durability/): reconnection, queueing, and heartbeat — defaults and every knob
+- [Middleware](https://durablews.imns.co/guides/middleware/): inbound and outbound interception, auth/token refresh, ordering semantics
+- [Codecs](https://durablews.imns.co/guides/codecs/): the wire-format seam; JSON default, custom codecs
+- [Vue](https://durablews.imns.co/frameworks/vue/): the useWebSocket composable (durablews/vue)
+- [React](https://durablews.imns.co/frameworks/react/): the useWebSocket hook (durablews/react)
+- [Why DurableWS?](https://durablews.imns.co/comparison/): honest comparison vs partysocket, reconnecting-websocket, socket.io
+- [Migrating from v1](https://durablews.imns.co/guides/migrating-from-v1/): the v2 breaking changes
+
+## Optional
+
+- [Architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md): the v2 design document and live implementation tracker
+- [GitHub](https://github.com/imnsco/DurableWS): source, issues, contributing

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -1,0 +1,86 @@
+---
+title: Why DurableWS?
+description: An honest comparison with reconnecting-websocket, partysocket, and socket.io.
+---
+
+The niche DurableWS lives in is *durable clients over the standard
+`WebSocket`*. Two libraries already live there, and one giant defines the
+category's expectations from outside it. Here's where we genuinely differ —
+including the places the alternatives are ahead today.
+
+## The landscape
+
+- **[reconnecting-websocket](https://github.com/pladaria/reconnecting-websocket)** —
+  the long-standing default for "a WebSocket that reconnects". Its last
+  release was in 2020; dozens of issues and PRs sit open.
+- **[partysocket](https://www.npmjs.com/package/partysocket)** — the
+  actively-maintained fork (PartyKit / Cloudflare), with bugfixes, pending
+  PRs, multi-platform support, and a React hook. If you want a maintained
+  drop-in `WebSocket` class today, this is the one to beat — and the one we
+  benchmark ourselves against.
+- **socket.io** — a different category. Its gravity is server-side (rooms,
+  namespaces, broadcast), its protocol requires a socket.io server, and its
+  client can't talk to a plain WebSocket server. If you control the server
+  and want rooms out of the box, use socket.io. If you have a plain
+  WebSocket endpoint and need a client that survives the real world — that's
+  this niche.
+
+## Feature comparison
+
+| | durablews | partysocket | reconnecting-websocket |
+| --- | --- | --- | --- |
+| Reconnection | ✅ exponential, **full jitter** | ✅ exponential | ✅ exponential |
+| Queue while disconnected | ✅ **bounded**, drop-oldest | ✅ unbounded by default | ✅ unbounded by default |
+| Observable drops | ✅ `drop` events, never silent | ❌ | ❌ |
+| Promise-based `connect()` | ✅ resolves on open, terminal-failure rejection | ❌ event-based | ❌ event-based |
+| Typed messages | ✅ generics + **Standard Schema** runtime validation | ❌ | ❌ |
+| Middleware | ✅ inbound **and** outbound (auth, async-safe, ordered) | ❌ | ❌ |
+| Pluggable codec | ✅ | ❌ | ❌ |
+| Heartbeat / idle detection | ✅ opt-in, any-inbound-counts | ❌ | ❌ |
+| Observable connection state | ✅ FSM + `subscribe()`/`getState()` snapshots | `readyState` | `readyState` |
+| Framework bindings | ✅ Vue **and** React, in the box | React | ❌ |
+| Drop-in `WebSocket` class | 🚧 planned (`durablews/compat`) | ✅ | ✅ |
+| Dynamic URL provider | ❌ (on the radar) | ✅ sync/async | ❌ |
+| Zero dependencies | ✅ | ✅ | ✅ |
+| Actively maintained | ✅ (alpha) | ✅ | last release 2020 |
+
+## What the differences mean in practice
+
+**Queueing you can reason about.** All three buffer messages while
+disconnected. The difference is what happens at the edges: DurableWS's queue
+is bounded (256 by default), drops the oldest when full, and **every** dropped
+message — overflow or connection-death — fires a `drop` event carrying exactly
+what you passed to `send()`. An unbounded silent buffer is a memory leak with
+a delay; a capped silent buffer is data loss with no witness.
+
+**Durability that composes.** Reconnecting is table stakes. The harder
+problem is everything attached to it: the message queued across a reconnect
+that should go out with a *fresh* auth token (outbound middleware runs at
+transmission time), the quiet-but-dead link (heartbeat closes it with code
+`4408` and lets the reconnect machinery recover), the UI that wants to show
+`reconnecting (attempt 3)` (an explicit state machine you can subscribe to,
+not a `readyState` integer).
+
+**Types end to end.** Pass a [Standard Schema](https://standardschema.dev)
+(zod, valibot, arktype, …) and inbound messages are typed *and*
+runtime-validated before your handlers or middleware see them. The
+alternatives hand you `MessageEvent["data"]`.
+
+## What the alternatives do better today
+
+Honesty over marketing:
+
+- **Drop-in `WebSocket` compatibility.** partysocket and
+  reconnecting-websocket are classes you swap in where a `WebSocket` goes —
+  including as the `webSocketImpl` of libraries like graphql-ws. DurableWS's
+  primary API is deliberately different (and, we'd argue, better); a
+  compat-shaped `durablews/compat` export is planned for exactly this
+  audience.
+- **Dynamic URL resolution.** partysocket accepts `url` as a sync or async
+  function, re-resolved per reconnect — handy for token-in-URL auth schemes.
+  DurableWS handles token freshness via outbound middleware, but per-connect
+  URL re-resolution isn't built yet.
+- **Years in production.** The reconnecting-websocket lineage has carried an
+  enormous amount of traffic. DurableWS 2.0 is an alpha with a thorough test
+  pyramid (unit, integration, real-browser e2e) — but production-miles are
+  earned, not claimed.

--- a/docs/src/content/docs/guides/codecs.md
+++ b/docs/src/content/docs/guides/codecs.md
@@ -1,0 +1,67 @@
+---
+title: Codecs
+description: The wire-format seam — JSON by default, swap in anything.
+---
+
+Every message crosses `encode`/`decode`, so the wire format is a first-class
+config option — not middleware:
+
+```ts
+interface Codec {
+    encode(data: unknown): string | BufferSource | Blob;
+    decode(data: unknown): unknown;
+}
+```
+
+`encode`'s return type deliberately mirrors `WebSocket.send`'s parameter, so
+the codec contract can never drift looser than what the socket accepts.
+
+## The default: JSON
+
+With no `codec` configured, `jsonCodec` applies:
+
+- **encode** — strings pass through as-is; binary (`ArrayBuffer`,
+  `ArrayBufferView`, `Blob`) passes through untouched; everything else is
+  `JSON.stringify`-ed.
+- **decode** — strings are `JSON.parse`-d with a safe fallback to the raw
+  string when they aren't JSON; binary frames pass through untouched.
+
+That means `client.send({ type: "hello" })` and `client.send(bytes)` both do
+the right thing with zero setup.
+
+## A custom codec
+
+```ts
+import { decode, encode } from "@msgpack/msgpack";
+import { defineClient, type Codec } from "durablews";
+
+const msgpackCodec: Codec = {
+    encode: (data) => encode(data),
+    decode: (data) =>
+        data instanceof ArrayBuffer ? decode(new Uint8Array(data)) : data
+};
+
+const client = defineClient({ url, codec: msgpackCodec });
+```
+
+:::tip[Binary frames arrive as `Blob` in browsers]
+Browsers deliver binary WebSocket frames as `Blob` by default. If your codec
+expects `ArrayBuffer`, handle both — or decode the `Blob` asynchronously in an
+inbound middleware instead, since `decode` is synchronous.
+:::
+
+## Where the codec sits
+
+```
+inbound:   frame → codec.decode → schema validation → middleware → message
+outbound:  send() → [queue] → outbound middleware → codec.encode → socket
+```
+
+Two consequences worth knowing:
+
+- [Schema validation](/getting-started/#typed-and-validated-messages) runs on
+  *decoded* values — your schema describes application messages, not wire
+  bytes.
+- Outbound middleware runs *before* encode, so middleware transforms plain
+  values and the codec owns serialization. A token-stamping middleware and a
+  msgpack codec compose without knowing about each other.

--- a/docs/src/content/docs/guides/durability.md
+++ b/docs/src/content/docs/guides/durability.md
@@ -1,0 +1,140 @@
+---
+title: Durability tuning
+description: Reconnection, queueing, and heartbeat — the defaults, and every knob.
+---
+
+DurableWS is durable by default: reconnection and queueing are **on** with
+zero configuration, heartbeat is opt-in. This page is every knob and the
+reasoning behind the defaults.
+
+## Reconnection
+
+Any close the user didn't ask for schedules a reconnect with **full-jitter
+exponential backoff**: each delay is drawn uniformly from
+`[0, min(maxDelay, baseDelay × factor^attempt)]`, so a fleet of clients
+dropped by the same outage doesn't retry in synchronized waves.
+
+```ts
+const client = defineClient({
+    url,
+    reconnect: {
+        baseDelay: 500,      // first-retry ceiling (ms)
+        factor: 2,           // exponential growth
+        maxDelay: 30_000,    // delay ceiling (ms)
+        jitter: true,        // full jitter (see above)
+        maxRetries: Infinity,
+        shouldReconnect: (event) => event.code !== 4001
+    }
+});
+```
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `baseDelay` | `500` | ms |
+| `factor` | `2` | |
+| `maxDelay` | `30_000` | ms |
+| `jitter` | `true` | `false` = exact exponential delays |
+| `maxRetries` | `Infinity` | per disconnection episode |
+| `shouldReconnect` | always | per-close veto; user `close()` never retries regardless |
+
+Disable entirely with `reconnect: false`.
+
+Each scheduled retry fires a `reconnecting` event (`{ attempt, delay }`), and
+`retryAttempt` appears in `getState()` — show it in your UI. A successful open
+resets the attempt counter.
+
+### `connect()` under unlimited retries
+
+`connect()` resolves on the **first successful open** — including when that
+open is a successful retry — and rejects only on *terminal* failure (retries
+exhausted, a `shouldReconnect` veto, or `close()` before the first open).
+Under the default `maxRetries: Infinity` it therefore **never rejects**:
+against a down host it stays pending while the client keeps trying. Need a
+deadline? Race it:
+
+```ts
+await Promise.race([
+    client.connect(),
+    new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("connect timeout")), 10_000)
+    )
+]);
+```
+
+### Vetoing by close code
+
+`shouldReconnect` receives the `CloseEvent`. The classic use is refusing to
+retry application-level rejections (e.g. an auth failure your server signals
+with a custom code) while still retrying infrastructure drops:
+
+```ts
+reconnect: {
+    shouldReconnect: ({ code }) => code !== 4001 // your "unauthorized" code
+}
+```
+
+## Queueing
+
+`send()` while `connecting` or `reconnecting` **queues** the message and
+flushes the backlog, in order, the moment the socket opens — before the `open`
+event fires, so queued messages precede anything an open-handler sends.
+
+The queue is **bounded** (default `256`) with a **drop-oldest** policy, and a
+drop is never silent: every dropped message fires a `drop` event carrying the
+exact value you passed to `send()` and the reason — `"overflow"` (queue was
+full) or `"close"` (the connection ended with messages still waiting).
+
+```ts
+const client = defineClient({ url, queue: { maxSize: 1000 } });
+
+client.on("drop", ({ data, reason }) => {
+    console.warn(`message not sent (${reason})`, data);
+});
+```
+
+`send()` still throws in states where no open is coming (`idle`, `closing`,
+`closed`), and always when `queue: false`.
+
+The queue stores the **raw values** you passed to `send()` — encoding (and
+outbound middleware) run at transmission time, so a message queued across a
+reconnect goes out with, e.g., a token that is fresh when it actually leaves.
+
+## Heartbeat
+
+Opt-in, because it requires a server that answers (or talks regularly for its
+own reasons) — an app-level contract the library can't assume:
+
+```ts
+const client = defineClient({
+    url,
+    heartbeat: {
+        interval: 15_000, // ping every 15s while open
+        message: "ping",  // run through the codec; default "ping"
+        timeout: 10_000   // default: interval
+    }
+});
+```
+
+While open, the client sends `message` every `interval`. **Any inbound frame**
+counts as liveness — a busy connection never pays for explicit pongs. If
+nothing arrives within `timeout` of a ping, the link is declared dead: an
+`error` is emitted, the socket is closed with the app-reserved code **4408**
+(exported as `HEARTBEAT_TIMEOUT_CODE`), and the close flows into the normal
+reconnect machinery.
+
+Heartbeat pings bypass outbound middleware — they are transport-level
+liveness, not app messages.
+
+## Observing all of it
+
+```ts
+const { state, lastError, retryAttempt, queueLength } = client.getState();
+
+const unsubscribe = client.subscribe(() => {
+    render(client.getState()); // fires on any snapshot change
+});
+```
+
+Snapshots are frozen and referentially stable between changes — see the
+[Vue](/frameworks/vue/) and [React](/frameworks/react/) bindings, which are
+built on exactly this pair.

--- a/docs/src/content/docs/guides/middleware.md
+++ b/docs/src/content/docs/guides/middleware.md
@@ -1,0 +1,112 @@
+---
+title: Middleware
+description: Intercept messages in both directions — auth, logging, filtering, transforms.
+---
+
+Middleware intercepts messages flowing through the client. It follows the
+onion model you know from Hono or Koa: each middleware receives a context and
+a `next()`, may transform `ctx.data`, may short-circuit by not calling
+`next()`, and may be async.
+
+A bare function registers **inbound** middleware; the object form registers
+per direction:
+
+```ts
+client.use((ctx, next) => { ... });                  // inbound
+client.use({ outbound: attachToken });               // outbound only
+client.use({ inbound: logIn, outbound: logOut });    // one logical middleware,
+                                                     // both directions
+```
+
+Middleware never adds client API — that's the [vocabulary](/reference/api/)
+boundary between middleware and plugins.
+
+## Inbound
+
+Runs after `codec.decode` (and after [schema validation](/getting-started/#typed-and-validated-messages),
+so middleware only ever sees trusted data), before the `message` event:
+
+```ts
+client.use((ctx, next) => {
+    console.log("received:", ctx.data);
+    ctx.data = normalize(ctx.data); // handlers see the transformed value
+    return next();
+});
+```
+
+Short-circuiting suppresses the `message` event — useful for protocol frames
+your handlers shouldn't see. The built-in `pingpong` middleware does exactly
+this: auto-replies to server pings without bubbling them.
+
+```ts
+import { pingpong } from "durablews";
+client.use(pingpong);
+```
+
+## Outbound
+
+Runs at **transmission time** — after the queue, before `codec.encode`. The
+flagship use case is auth:
+
+```ts
+client.use({
+    outbound: async (ctx, next) => {
+        ctx.data = { ...ctx.data, token: await getFreshToken() };
+        await next();
+    }
+});
+```
+
+Transmission-time execution is a durability feature: a message queued across a
+30-second reconnect is stamped with a token that is fresh *when it actually
+goes out*, not when you called `send()`. It also means `drop` events always
+carry the raw value you passed to `send()` — never a half-transformed one.
+
+### Ordering (and its honest cost)
+
+Outbound middleware may be async, and the outbound path is **serialized**:
+messages reach the socket in `send()` order even while an earlier message's
+middleware awaits. When nothing is in flight and the chain is synchronous,
+`send()` stays fully synchronous — zero overhead.
+
+The flip side: a middleware that delays one message delays everything behind
+it (head-of-line). That's correct for the things middleware is for — pacing
+the stream *means* delaying it; a token refresh blocking sends is what
+freshness requires. Policies that want to selectively delay or collapse
+*specific* messages (per-key debounce, batching) inherently want reordering,
+which the pipeline refuses. Compose those in front of `send()` instead:
+
+```ts
+const sendTyping = debounce((s) => client.send(s), 300);
+```
+
+Same composability, different layer — and unrelated messages never wait.
+
+### Failure semantics
+
+- **Short-circuit** (returning without `next()`) means *deliberately not
+  sent*. No `drop` event — `drop` means the library couldn't deliver
+  something; this is your policy choosing not to.
+- **A throw or rejection** surfaces as an `error` event and skips **only that
+  message**; everything behind it continues.
+- **Connection drops mid-pipeline** (an async middleware was awaiting when
+  the socket died): if a reconnect is underway the original value is
+  re-queued ahead of newer sends; otherwise it surfaces as a `drop`. Never
+  silently lost.
+- **Heartbeat pings bypass outbound middleware** entirely.
+
+## Writing middleware once, typing it
+
+Middleware is typed by the client's generics: inbound contexts carry `TIn`,
+outbound contexts carry `TOut`.
+
+```ts
+const client = defineClient<ServerMsg, ClientMsg>({ url });
+
+client.use({
+    outbound: (ctx, next) => {
+        ctx.data; // ClientMsg
+        return next();
+    }
+});
+```

--- a/docs/src/content/docs/guides/migrating-from-v1.md
+++ b/docs/src/content/docs/guides/migrating-from-v1.md
@@ -1,0 +1,68 @@
+---
+title: Migrating from v1
+description: What changed between durablews 1.x and 2.0.
+---
+
+v2 is a ground-up rewrite. v1's README advertised durability features the code
+didn't implement; v2 implements them. The API breaks — deliberately and once.
+
+## The store is gone
+
+v1 was a Redux-style store: `defineStore`, `dispatch`, `defineAction`,
+`composeActions`, reducers over connection state. All of it is removed. The
+connection lifecycle is now a typed finite state machine the library owns, and
+**messages are never accumulated in state** (v1's default handler retained
+every message forever — an unbounded leak).
+
+```ts
+// v1
+const store = defineStore({ url });
+store.dispatch("connect");
+
+// v2
+const client = defineClient({ url });
+await client.connect();
+```
+
+If you used the store for app state: deliver messages into your own state
+tool (a `message` handler that writes to your store of choice) — core stays
+out of app state by design.
+
+## No more singleton
+
+v1's `defineClient` cached a module-level instance and silently ignored config
+on the second call. v2 returns a **fresh client per call**; export your own
+instance if you want a singleton:
+
+```ts
+// src/ws.ts
+export const ws = defineClient({ url });
+```
+
+## Event names follow the WebSocket standard
+
+| v1 | v2 |
+| --- | --- |
+| `connected` | `open` |
+| `closed` (never fired — the v1 bug) | `close` |
+| — | `statechange`, `reconnecting`, `drop` |
+
+```ts
+client.on("open", () => {});
+client.on("message", (msg) => {});
+client.on("close", (event) => {});
+```
+
+## send() semantics
+
+v1's `send()` silently dropped messages when the socket wasn't open. v2
+**queues** during `connecting`/`reconnecting` (bounded, drop-oldest, with
+`drop` events) and **throws** in states where no open is coming. Nothing is
+ever silently lost.
+
+## What you get for the migration
+
+Everything v1 promised, real this time: automatic reconnection with
+full-jitter backoff, bounded message queueing, opt-in heartbeat, plus typed +
+schema-validated messages, middleware in both directions, a pluggable codec,
+and Vue/React bindings in the box. See [Getting started](/getting-started/).

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -1,0 +1,83 @@
+---
+title: API reference
+description: Every export of durablews, durablews/vue, and durablews/react.
+---
+
+## `defineClient(config)`
+
+Creates a new client. Every call returns an independent instance — there is no
+shared singleton.
+
+```ts
+import { defineClient } from "durablews";
+
+const client = defineClient({ url: "wss://example.com/socket" });
+```
+
+Typing, three ways: pass a `schema` (types inferred + runtime validation),
+pass generics (`defineClient<Incoming, Outgoing>(config)`), or neither
+(messages are `unknown`).
+
+### Config
+
+| Option | Type | Default | |
+| --- | --- | --- | --- |
+| `url` | `string \| URL` | — | required |
+| `protocols` | `string \| string[]` | — | passed to the underlying `WebSocket` |
+| `codec` | `Codec` | `jsonCodec` | [the wire seam](/guides/codecs/) |
+| `reconnect` | `false \| ReconnectOptions` | on | [durability tuning](/guides/durability/#reconnection) |
+| `queue` | `false \| QueueOptions` | on, `maxSize: 256` | [queueing](/guides/durability/#queueing) |
+| `heartbeat` | `HeartbeatOptions` | off | [heartbeat](/guides/durability/#heartbeat) |
+| `schema` | `StandardSchemaV1` | — | [typed messages](/getting-started/#typed-and-validated-messages) |
+
+## The client
+
+| Member | Signature | Notes |
+| --- | --- | --- |
+| `state` | `ConnectionState` | live getter: `idle \| connecting \| open \| closing \| reconnecting \| closed` |
+| `connect()` | `() => Promise<void>` | resolves on first open (incl. a successful retry); idempotent; rejects only on terminal failure — [details](/guides/durability/#connect-under-unlimited-retries) |
+| `send(data)` | `(data: TOut) => void` | queues while `connecting`/`reconnecting`; throws in `idle`/`closing`/`closed` |
+| `close(code?, reason?)` | | never triggers reconnection |
+| `on(event, handler)` | returns unsubscribe | typed per event (below) |
+| `use(middleware)` | returns the client | bare function = inbound; `{ inbound?, outbound? }` = per direction — [middleware](/guides/middleware/) |
+| `getState()` | `() => ClientState` | frozen `{ state, lastError, retryAttempt, queueLength }`; referentially stable between changes |
+| `subscribe(listener)` | returns unsubscribe | fires on **any** snapshot change |
+
+### Events
+
+| Event | Payload | Fires when |
+| --- | --- | --- |
+| `open` | — | the socket opened (after the queue flushed) |
+| `message` | `TIn` | a message was decoded and (if configured) validated |
+| `close` | `CloseEvent` | the socket closed, clean or not |
+| `error` | `Event \| Error` | transport error, middleware throw, schema failure (`SchemaValidationError`), heartbeat timeout |
+| `statechange` | `{ previous, current }` | the FSM transitioned |
+| `reconnecting` | `{ attempt, delay }` | a retry was scheduled (once per attempt) |
+| `drop` | `{ data: TOut, reason: "overflow" \| "close" }` | a queued message will never be sent |
+
+## Other exports
+
+| Export | What it is |
+| --- | --- |
+| `jsonCodec` | the default codec (JSON with binary passthrough) |
+| `pingpong` | opt-in inbound middleware: auto-replies to `"ping"` with `"pong"`, without emitting `message` |
+| `RECONNECT_DEFAULTS` / `QUEUE_DEFAULTS` | the resolved default option values |
+| `HEARTBEAT_TIMEOUT_CODE` | `4408` — the close code a heartbeat timeout uses (filter it in `shouldReconnect`) |
+| `SchemaValidationError` | the `error` payload for invalid inbound messages; carries the schema's `issues` |
+
+All public types are exported: `WebSocketClient`, `WebSocketClientConfig`,
+`Codec`, `ConnectionState`, `ClientState`, `ClientEventMap`, `Middleware`,
+`MessageContext`, `OutboundMiddleware`, `OutboundContext`,
+`DirectionalMiddleware`, `ReconnectOptions`, `QueueOptions`,
+`HeartbeatOptions`, `DropEvent`, `ReconnectingEvent`, `StateChange`,
+`StandardSchemaV1`.
+
+## Subpath exports
+
+| Subpath | Export | |
+| --- | --- | --- |
+| `durablews/vue` | `useWebSocket` composable | [Vue guide](/frameworks/vue/) — optional peer `vue >= 3.2` |
+| `durablews/react` | `useWebSocket` hook | [React guide](/frameworks/react/) — optional peer `react >= 18` |
+
+Installing `durablews` without the frameworks never warns; framework code
+loads only via its subpath.

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -60,10 +60,14 @@ The real incumbents in our niche — durable clients over the standard
 - **`partysocket`** — the maintained fork (PartyKit/Cloudflare), actively
   growing. This is the rival evaluators will compare us against.
 
-Differentiation vs. both: typed events, the codec seam, middleware, **message
-queueing** (partysocket does not queue), a promise-based `connect()`, and an
-observable FSM. This story must be explicit — a comparison page is among the
-highest-leverage docs we can ship (M4).
+Differentiation vs. both: typed events, the codec seam, middleware, **bounded
+and observable queueing**, a promise-based `connect()`, and an observable FSM.
+*(Correction, M4 slice 4: an earlier revision claimed "partysocket does not
+queue" — false. Both incumbents buffer while disconnected, unbounded by
+default with a silent `maxEnqueuedMessages` cap. The honest differentiator is
+the queue's edges: bounded by default, drop-oldest, and every drop observable
+via `drop` events — never a silent buffer.)* This story must be explicit — a
+comparison page is among the highest-leverage docs we can ship (M4).
 
 Both incumbents win adoption via a **drop-in `WebSocket`-compatible class**
 (swap `new WebSocket(url)` → `new PartySocket(...)`). Our nicer API is a
@@ -612,10 +616,15 @@ stops moving; release is last.
   as a `drop` otherwise — never silently lost. New types: `OutboundContext`,
   `OutboundMiddleware`, `DirectionalMiddleware`. Corrects the §4.1 status
   note; e2e proves async stamping + ordering against a real socket.
-- ⬜ **Slice 4 — Docs content.** API reference, guides (durability tuning,
-  codecs, middleware, framework pages), migration-from-v1 note, the
-  **comparison page** (vs `reconnecting-websocket`, `partysocket`, socket.io
-  category expectations), and **`llms.txt`** for AI-assistant discovery.
+- ✅ **Slice 4 — Docs content.** API reference (hand-written single page —
+  typedoc deferred until the surface outgrows it), guides (durability
+  tuning, middleware, codecs; framework pages landed in slice 2b),
+  migration-from-v1, the **comparison page** ("Why DurableWS?" — claims
+  verified against the incumbents' current READMEs, with an explicit
+  "what they do better today" section: drop-in compat, dynamic URL
+  providers, production miles), and **`llms.txt`** (hand-written, in
+  `docs/public/`) for AI-assistant discovery. Also corrects §2.1's false
+  "partysocket does not queue" claim (see the correction note there).
 - ⬜ **Slice 5 — `durablews/compat` (decision: build, with scoped fidelity).**
   A drop-in `WebSocket`-shaped class over core for two documented audiences:
   app-code one-line migration (the `reconnecting-websocket`/`partysocket`


### PR DESCRIPTION
## Summary

M4 slice 4 — the docs-content slice. Six new pages + `llms.txt`:

- **Guides**: [Durability tuning](docs/src/content/docs/guides/durability.md) (every knob, defaults table, veto/deadline recipes), [Middleware](docs/src/content/docs/guides/middleware.md) (both directions, the ordering/head-of-line story, failure semantics), [Codecs](docs/src/content/docs/guides/codecs.md), [Migrating from v1](docs/src/content/docs/guides/migrating-from-v1.md).
- **Reference**: hand-written [API reference](docs/src/content/docs/reference/api.md) covering the full current surface (typedoc deferred until the surface outgrows a single page).
- **[Why DurableWS?](docs/src/content/docs/comparison.md)** — the comparison page. Every claim verified against the incumbents' current READMEs before publishing, and it includes an explicit **"what the alternatives do better today"** section (drop-in compat, partysocket's dynamic URL providers, production miles) — credibility over marketing.
- **`llms.txt`** in `docs/public/` for AI-assistant discovery.

## Notable: an RFC correction

Verification caught a false claim we'd been carrying: §2.1 said *"partysocket does not queue."* It does — both incumbents buffer while disconnected (unbounded by default, silent cap via `maxEnqueuedMessages`). The RFC now carries a correction note, and the comparison page states the honest differentiator: our queue is **bounded by default, drop-oldest, with every drop observable** via `drop` events. The strategy is unchanged — the edge cases were always the real story — but the headline claim is now true.

RFC §8: slice 4 ✅. Remaining in M4: compat (5), cross-runtime e2e + size budget (6), release (7).