### PR TITLE
chore(release): switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,17 @@ concurrency: release-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
-  id-token: write # npm provenance
+  id-token: write # npm trusted publishing (OIDC) + provenance
 
 jobs:
   release:
     name: Version or publish
     runs-on: ubuntu-latest
-    # Gated until the NPM_TOKEN secret exists (mirrors DOCS_DEPLOY_ENABLED):
-    # flip the NPM_PUBLISH_ENABLED repo variable to "true" to activate.
+    # Kill switch: set the NPM_PUBLISH_ENABLED repo variable to "true".
     if: github.repository == 'imnsco/DurableWS' && vars.NPM_PUBLISH_ENABLED == 'true'
+    # Must match the npm Trusted Publisher registration (repo + workflow
+    # file + environment); the OIDC token carries the environment claim.
+    environment: production
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm
@@ -27,12 +29,17 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+      # Trusted publishing requires npm >= 11.5.1; Node 22 bundles npm 10.
+      # No registry-url/.npmrc token setup: with no token present, npm
+      # authenticates via the runner's OIDC token and attaches provenance
+      # automatically.
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       # With pending changesets: opens/updates the "Version Packages" PR.
-      # Without (i.e. the Version PR just merged): builds and publishes to npm
-      # under the dist-tag changesets derives from pre mode ("alpha").
+      # Without (i.e. the Version PR just merged): builds and publishes to
+      # npm under the dist-tag changesets derives from pre mode ("alpha").
       - name: Version PR or publish
         uses: changesets/action@v1
         with:
@@ -42,5 +49,3 @@ jobs:
           title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary

Aligns `release.yml` with the npm **Trusted Publisher** registered for this repo (`imnsco/DurableWS` → `release.yml` → environment `production`). With OIDC, **no `NPM_TOKEN` secret is needed at all** — npm verifies the workflow's identity directly and provenance is attached automatically.

Changes:
- `environment: production` on the release job — the OIDC token must carry the environment claim that the trusted publisher was registered with, or npm rejects the publish.
- `npm install -g npm@latest` step — trusted publishing requires npm ≥ 11.5.1; Node 22 bundles npm 10.
- Removed `registry-url` from setup-node and the `NODE_AUTH_TOKEN` env — a token-bearing `.npmrc` (even with an empty token) would make npm attempt token auth instead of falling back to OIDC.
- The `NPM_PUBLISH_ENABLED` variable gate stays as the kill switch. Flipping it to `true` is the arming step, deliberately left to the maintainer.

Still required on the GitHub side: Settings → Actions → General → **"Allow GitHub Actions to create and approve pull requests"** (the changesets action opens the Version Packages PR with the plain `GITHUB_TOKEN`).