### PR TITLE
feat(compat): drop-in WebSocket class over the durable core (M4 slice 5)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
                         { label: "Durability tuning", slug: "guides/durability" },
                         { label: "Middleware", slug: "guides/middleware" },
                         { label: "Codecs", slug: "guides/codecs" },
+                        { label: "Drop-in compat", slug: "guides/compat" },
                         {
                             label: "Migrating from v1",
                             slug: "guides/migrating-from-v1",

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -28,6 +28,7 @@ client.send({ type: "hello" });
 - [Durability tuning](https://durablews.imns.co/guides/durability/): reconnection, queueing, and heartbeat — defaults and every knob
 - [Middleware](https://durablews.imns.co/guides/middleware/): inbound and outbound interception, auth/token refresh, ordering semantics
 - [Codecs](https://durablews.imns.co/guides/codecs/): the wire-format seam; JSON default, custom codecs
+- [Drop-in compat](https://durablews.imns.co/guides/compat/): the WebSocket-shaped class (durablews/compat) for app-code migration and webSocketImpl injection, with its known-deviations table
 - [Vue](https://durablews.imns.co/frameworks/vue/): the useWebSocket composable (durablews/vue)
 - [React](https://durablews.imns.co/frameworks/react/): the useWebSocket hook (durablews/react)
 - [Why DurableWS?](https://durablews.imns.co/comparison/): honest comparison vs partysocket, reconnecting-websocket, socket.io

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -39,7 +39,7 @@ including the places the alternatives are ahead today.
 | Heartbeat / idle detection | ✅ opt-in, any-inbound-counts | ❌ | ❌ |
 | Observable connection state | ✅ FSM + `subscribe()`/`getState()` snapshots | `readyState` | `readyState` |
 | Framework bindings | ✅ Vue **and** React, in the box | React | ❌ |
-| Drop-in `WebSocket` class | 🚧 planned (`durablews/compat`) | ✅ | ✅ |
+| Drop-in `WebSocket` class | ✅ [`durablews/compat`](/guides/compat/) | ✅ | ✅ |
 | Dynamic URL provider | ❌ (on the radar) | ✅ sync/async | ❌ |
 | Zero dependencies | ✅ | ✅ | ✅ |
 | Actively maintained | ✅ (alpha) | ✅ | last release 2020 |
@@ -70,12 +70,6 @@ alternatives hand you `MessageEvent["data"]`.
 
 Honesty over marketing:
 
-- **Drop-in `WebSocket` compatibility.** partysocket and
-  reconnecting-websocket are classes you swap in where a `WebSocket` goes —
-  including as the `webSocketImpl` of libraries like graphql-ws. DurableWS's
-  primary API is deliberately different (and, we'd argue, better); a
-  compat-shaped `durablews/compat` export is planned for exactly this
-  audience.
 - **Dynamic URL resolution.** partysocket accepts `url` as a sync or async
   function, re-resolved per reconnect — handy for token-in-URL auth schemes.
   DurableWS handles token freshness via outbound middleware, but per-connect

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -142,6 +142,10 @@ bypass outbound middleware entirely.
   a [React hook](/frameworks/react/) (`durablews/vue`, `durablews/react`) with
   reactive connection state and automatic cleanup; the frameworks are optional
   peers, so core installs never warn
+- **A drop-in `WebSocket` class** —
+  [`durablews/compat`](/guides/compat/): swap it in where a socket goes (or
+  inject it as a library's `webSocketImpl`) and get the durable core
+  underneath, with a published known-deviations table
 
 :::note[`connect()` and unlimited retries]
 `connect()` resolves on the first successful open — including when that open is
@@ -153,7 +157,6 @@ it: `Promise.race([client.connect(), timeout(10_000)])`.
 
 ## On the roadmap
 
-A drop-in `WebSocket`-compatible compat class, expanded guides and an API
-reference, and channels — see the
+Runnable examples, cross-runtime e2e proof (Deno/Bun), and channels — see the
 [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
 for the full plan and status.

--- a/docs/src/content/docs/guides/compat.md
+++ b/docs/src/content/docs/guides/compat.md
@@ -1,0 +1,88 @@
+---
+title: Drop-in compat
+description: A WebSocket-shaped class over the durable core — durablews/compat.
+---
+
+`durablews/compat` exports a class shaped like the native `WebSocket`, with
+the durable core underneath: automatic reconnection with full-jitter backoff,
+bounded queueing, opt-in heartbeat. It exists for two audiences:
+
+1. **App code that constructs sockets directly** — the
+   `reconnecting-websocket` / `partysocket` crowd. Migration is one line.
+2. **Libraries with a `webSocketImpl`-style injection point** — graphql-ws,
+   y-websocket, realtime SDKs. Inject durability into tools that never learn
+   durablews exists.
+
+```ts
+import { WebSocket } from "durablews/compat";
+
+const ws = new WebSocket("wss://example.com/socket");
+ws.onmessage = (event) => console.log(event.data);
+ws.send("hello");
+```
+
+The class is also exported as `DurableWebSocket` if you prefer not to shadow
+the global name.
+
+## Injection
+
+```ts
+// graphql-ws
+import { createClient } from "graphql-ws";
+import { WebSocket } from "durablews/compat";
+
+const client = createClient({
+    url: "wss://example.com/graphql",
+    webSocketImpl: WebSocket
+});
+```
+
+```ts
+// y-websocket
+import { WebsocketProvider } from "y-websocket";
+import { WebSocket } from "durablews/compat";
+
+const provider = new WebsocketProvider(url, room, doc, {
+    WebSocketPolyfill: WebSocket
+});
+```
+
+## Tuning the durability
+
+The third constructor argument takes the durablews config (everything except
+`codec` and `schema` — compat is deliberately wire-faithful, byte in, byte
+out):
+
+```ts
+const ws = new WebSocket(url, undefined, {
+    reconnect: { maxDelay: 10_000 },
+    queue: { maxSize: 1000 },
+    heartbeat: { interval: 15_000 }
+});
+```
+
+And the full durablews client sits underneath as the escape hatch:
+
+```ts
+ws.client.on("reconnecting", ({ attempt }) => showBanner(attempt));
+ws.client.on("drop", ({ data }) => log("not sent", data));
+```
+
+## Known deviations
+
+A drop-in that quietly diverges is worse than one that tells you where. The
+deviations, exhaustively:
+
+| Behavior | Native `WebSocket` | `durablews/compat` |
+| --- | --- | --- |
+| `readyState` across disconnects | one-shot: never leaves `CLOSED` | returns to `CONNECTING` during automatic reconnects — the entire point |
+| `send()` while `CONNECTING` | throws `InvalidStateError` | **queues**, flushes in order on open |
+| `close` events | once, at the end | once per dropped connection (each followed by reconnection) |
+| `protocol` / `extensions` | negotiated values | always `""` |
+| `bufferedAmount` | bytes pending on the socket | always `0` |
+| `binaryType` set *after* construction | reconfigures the socket | emulated: `Blob` frames are converted on delivery (order-preserving, one copy). Prefer `{ binaryType: "arraybuffer" }` in the options, which configures the socket itself |
+| `send()` after `close()` | silently discarded | silently discarded (matched) |
+
+If one of these deviations matters to your integration, use the primary
+[`defineClient`](/reference/api/) API instead — it doesn't pretend to be a
+one-shot socket, so none of these tensions exist there.

--- a/packages/durablews/e2e/client.e2e.ts
+++ b/packages/durablews/e2e/client.e2e.ts
@@ -239,3 +239,40 @@ test("outbound middleware stamps messages before they reach the wire", async ({
         { body: "two", token: "tok-123" }
     ]);
 });
+
+test("compat: the drop-in WebSocket survives a server drop", async ({
+    page
+}) => {
+    await page.goto("/e2e/app.html");
+
+    const result = await page.evaluate(async (wsUrl) => {
+        const { WebSocket: DWS } = await import("/dist/compat.js");
+        const ws = new DWS(wsUrl, undefined, {
+            reconnect: { baseDelay: 50, jitter: false }
+        });
+        const echoed: unknown[] = [];
+        ws.onmessage = (event: MessageEvent) => echoed.push(event.data);
+        await new Promise<void>((resolve) =>
+            ws.addEventListener("open", () => resolve(), { once: true })
+        );
+        const openState = ws.readyState;
+
+        ws.send("raw-one");
+        await new Promise((r) => setTimeout(r, 200));
+        ws.send("drop"); // the server closes this connection (code 1012)
+        await new Promise((r) => setTimeout(r, 600));
+        const recovered = ws.readyState;
+
+        ws.send("raw-two");
+        await new Promise((r) => setTimeout(r, 200));
+        ws.close();
+
+        return { openState, recovered, echoed };
+    }, `ws://localhost:${server.port}`);
+
+    expect(result.openState).toBe(1); // OPEN
+    expect(result.recovered).toBe(1); // OPEN again, post-reconnect
+    // Wire-faithful echoes: raw strings, no JSON wrapping.
+    expect(result.echoed).toContain("raw-one");
+    expect(result.echoed).toContain("raw-two");
+});

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -36,6 +36,16 @@
                 "types": "./dist/react.d.cts",
                 "default": "./dist/react.cjs"
             }
+        },
+        "./compat": {
+            "import": {
+                "types": "./dist/compat.d.ts",
+                "default": "./dist/compat.js"
+            },
+            "require": {
+                "types": "./dist/compat.d.cts",
+                "default": "./dist/compat.cjs"
+            }
         }
     },
     "sideEffects": false,

--- a/packages/durablews/src/client.ts
+++ b/packages/durablews/src/client.ts
@@ -343,6 +343,9 @@ export function client(config: WebSocketClientConfig): WebSocketClient {
         socket = config.protocols
             ? new WebSocket(config.url, config.protocols)
             : new WebSocket(config.url);
+        if (config.binaryType) {
+            socket.binaryType = config.binaryType;
+        }
 
         socket.onopen = () => {
             retryAttempt = 0;

--- a/packages/durablews/src/compat.ts
+++ b/packages/durablews/src/compat.ts
@@ -1,0 +1,282 @@
+/**
+ * Drop-in `WebSocket` compatibility — `import { WebSocket } from "durablews/compat"`.
+ *
+ * A `WebSocket`-shaped class over the durable core, for two audiences:
+ * one-line migration of app code that constructs sockets directly, and
+ * `webSocketImpl`-style injection points in existing libraries (graphql-ws,
+ * y-websocket, realtime SDKs). Fidelity is scoped to those use cases — the
+ * known deviations are documented on the docs site, not hidden.
+ */
+import { client } from "@/client";
+import type { Codec, WebSocketClient, WebSocketClientConfig } from "@/types";
+
+/**
+ * Compat is wire-faithful: no JSON, no transforms. What you send is what the
+ * socket sends; what arrives is what you receive.
+ */
+const rawCodec: Codec = {
+    // The class's send() signature restricts inputs to WebSocket-sendable
+    // values, so the cast only widens what TypeScript already enforced there.
+    encode: (data) => data as string | BufferSource | Blob,
+    decode: (data) => data
+};
+
+type CloseEventInitLike = {
+    code?: number;
+    reason?: string;
+    wasClean?: boolean;
+};
+
+/**
+ * `CloseEvent` exists in browsers, Deno, Bun, and recent Node — but not in
+ * every runtime durablews supports, so fall back to a structural equivalent.
+ */
+const CloseEventCtor: new (
+    type: string,
+    init?: CloseEventInitLike
+) => CloseEvent =
+    typeof CloseEvent !== "undefined"
+        ? CloseEvent
+        : (class extends Event {
+              readonly code: number;
+              readonly reason: string;
+              readonly wasClean: boolean;
+              constructor(type: string, init: CloseEventInitLike = {}) {
+                  super(type);
+                  this.code = init.code ?? 0;
+                  this.reason = init.reason ?? "";
+                  this.wasClean = init.wasClean ?? false;
+              }
+          } as unknown as new (
+              type: string,
+              init?: CloseEventInitLike
+          ) => CloseEvent);
+
+/** The durablews options accepted as the constructor's third argument. */
+export type DurableWebSocketOptions = Omit<
+    WebSocketClientConfig,
+    "url" | "protocols" | "codec" | "schema"
+>;
+
+/**
+ * A drop-in `WebSocket` that reconnects, with the durable core underneath:
+ * full-jitter backoff, bounded queueing, opt-in heartbeat.
+ *
+ * ```ts
+ * import { WebSocket } from "durablews/compat";
+ *
+ * const ws = new WebSocket("wss://example.com/socket");
+ * ws.onmessage = (event) => console.log(event.data);
+ * ```
+ *
+ * Or injected where a library accepts an implementation:
+ *
+ * ```ts
+ * createClient({ url, webSocketImpl: WebSocket }); // graphql-ws
+ * ```
+ *
+ * The underlying durablews client is exposed as `.client` for everything the
+ * `WebSocket` shape can't say (state machine, `drop` events, middleware).
+ */
+export class DurableWebSocket extends EventTarget {
+    static readonly CONNECTING = 0 as const;
+    static readonly OPEN = 1 as const;
+    static readonly CLOSING = 2 as const;
+    static readonly CLOSED = 3 as const;
+
+    readonly CONNECTING = 0 as const;
+    readonly OPEN = 1 as const;
+    readonly CLOSING = 2 as const;
+    readonly CLOSED = 3 as const;
+
+    /** The underlying durablews client — the escape hatch to the full API. */
+    readonly client: WebSocketClient;
+
+    readonly url: string;
+    /** Always `""` — see the known-deviations table in the docs. */
+    readonly protocol = "";
+    /** Always `""` — see the known-deviations table in the docs. */
+    readonly extensions = "";
+    /** Always `0` — see the known-deviations table in the docs. */
+    readonly bufferedAmount = 0;
+
+    onopen: ((event: Event) => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onclose: ((event: CloseEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+
+    #binaryType: BinaryType;
+    // Serializes Blob → ArrayBuffer conversions so message order survives the
+    // async hop when binaryType is reassigned after construction. While no
+    // conversion is pending, delivery is fully synchronous (native-faithful).
+    #deliveryChain: Promise<void> = Promise.resolve();
+    #pendingDeliveries = 0;
+
+    constructor(
+        url: string | URL,
+        protocols?: string | string[],
+        options: DurableWebSocketOptions = {}
+    ) {
+        super();
+        this.url = String(url);
+        this.#binaryType = options.binaryType ?? "blob";
+        this.client = client({
+            ...options,
+            url,
+            protocols,
+            codec: rawCodec
+        });
+
+        this.client.on("open", () => {
+            const event = new Event("open");
+            this.dispatchEvent(event);
+            this.onopen?.call(this, event);
+        });
+        this.client.on("message", (data) => {
+            this.#deliverMessage(data);
+        });
+        this.client.on("close", (event) => {
+            // Re-dispatched as a fresh event: the original already completed
+            // its dispatch on the underlying socket.
+            const compatEvent = new CloseEventCtor("close", {
+                code: event.code,
+                reason: event.reason,
+                wasClean: event.wasClean
+            });
+            this.dispatchEvent(compatEvent);
+            this.onclose?.call(this, compatEvent);
+        });
+        this.client.on("error", () => {
+            // Native WebSocket error events carry no payload either.
+            const event = new Event("error");
+            this.dispatchEvent(event);
+            this.onerror?.call(this, event);
+        });
+
+        // A WebSocket connects on construction. Failures surface as
+        // error/close events, exactly like the native class.
+        this.client.connect().catch(() => {});
+    }
+
+    /**
+     * Maps the durable lifecycle onto the four native states. Deviation by
+     * design: during automatic reconnection this returns to `CONNECTING`,
+     * which a native (one-shot) socket can never do.
+     */
+    get readyState(): number {
+        switch (this.client.state) {
+            case "open":
+                return DurableWebSocket.OPEN;
+            case "closing":
+                return DurableWebSocket.CLOSING;
+            case "closed":
+                return DurableWebSocket.CLOSED;
+            default: // idle | connecting | reconnecting
+                return DurableWebSocket.CONNECTING;
+        }
+    }
+
+    get binaryType(): BinaryType {
+        return this.#binaryType;
+    }
+
+    /**
+     * Honored at any time: when set to `"arraybuffer"` after construction,
+     * `Blob` frames are converted on delivery (order-preserving). Prefer
+     * passing `binaryType` in the constructor options, which configures the
+     * socket itself and avoids the conversion copy.
+     */
+    set binaryType(value: BinaryType) {
+        this.#binaryType = value;
+    }
+
+    /**
+     * Sends data, with durability semantics: while (re)connecting the message
+     * is queued and flushed on open (a native socket would throw). After
+     * `close()` it is silently discarded, matching native behavior.
+     */
+    send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+        if (
+            this.client.state === "idle" ||
+            this.client.state === "closing" ||
+            this.client.state === "closed"
+        ) {
+            // Native sockets don't throw on send-after-close; stay faithful.
+            return;
+        }
+        this.client.send(data);
+    }
+
+    close(code?: number, reason?: string) {
+        this.client.close(code, reason);
+    }
+
+    #deliverMessage(data: unknown) {
+        const dispatch = (value: unknown) => {
+            const event = new MessageEvent("message", { data: value });
+            this.dispatchEvent(event);
+            this.onmessage?.call(this, event);
+        };
+        // Emulation path: binaryType was set to "arraybuffer" after
+        // construction, but the socket is still delivering Blobs.
+        if (
+            this.#binaryType === "arraybuffer" &&
+            typeof Blob !== "undefined" &&
+            data instanceof Blob
+        ) {
+            this.#queueDelivery(async () => {
+                try {
+                    dispatch(await blobToArrayBuffer(data));
+                } catch {
+                    // Conversion unavailable: raw delivery beats silence.
+                    dispatch(data);
+                }
+            });
+            return;
+        }
+        if (this.#pendingDeliveries === 0) {
+            // The common case: no conversion in flight → synchronous,
+            // exactly like a native socket.
+            dispatch(data);
+            return;
+        }
+        // A conversion is ahead of us: queue behind it to preserve order.
+        this.#queueDelivery(() => {
+            dispatch(data);
+        });
+    }
+
+    #queueDelivery(deliver: () => void | Promise<void>) {
+        this.#pendingDeliveries += 1;
+        this.#deliveryChain = this.#deliveryChain
+            .then(deliver)
+            // A listener throwing must not poison the chain for later
+            // messages; native dispatch isolates listener errors too.
+            .catch(() => {})
+            .finally(() => {
+                this.#pendingDeliveries -= 1;
+            });
+    }
+}
+
+/**
+ * `Blob.arrayBuffer()` with a `FileReader` fallback — jsdom (a popular test
+ * environment for apps using this class) ships `Blob` without the method.
+ */
+function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+    if (typeof blob.arrayBuffer === "function") {
+        return blob.arrayBuffer();
+    }
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            resolve(reader.result as ArrayBuffer);
+        };
+        reader.onerror = () => {
+            reject(reader.error ?? new Error("Blob read failed"));
+        };
+        reader.readAsArrayBuffer(blob);
+    });
+}
+
+export { DurableWebSocket as WebSocket };

--- a/packages/durablews/src/types.ts
+++ b/packages/durablews/src/types.ts
@@ -91,6 +91,12 @@ export interface WebSocketClientConfig {
     readonly url: string | URL;
     /** Optional subprotocol(s) passed to the underlying `WebSocket`. */
     readonly protocols?: string | string[];
+    /**
+     * `binaryType` applied to the underlying socket on every (re)connect:
+     * `"arraybuffer"` delivers binary frames as `ArrayBuffer` instead of the
+     * browser default `Blob`.
+     */
+    readonly binaryType?: BinaryType;
     /** Wire-format codec. Defaults to JSON (`jsonCodec`). */
     readonly codec?: Codec;
     /**

--- a/packages/durablews/tests/compat.test.ts
+++ b/packages/durablews/tests/compat.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WS from "vitest-websocket-mock";
+import { WebSocket as CompatWS, DurableWebSocket } from "../src/compat";
+
+const URL = "ws://localhost:1245";
+
+describe("durablews/compat", () => {
+    let server: WS;
+
+    beforeEach(() => {
+        server = new WS(URL);
+    });
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    function makeSocket(options = {}) {
+        return new DurableWebSocket(URL, undefined, {
+            reconnect: false,
+            ...options
+        });
+    }
+
+    it("exposes the native constants, statically and per instance", () => {
+        expect(DurableWebSocket.CONNECTING).toBe(0);
+        expect(DurableWebSocket.OPEN).toBe(1);
+        expect(DurableWebSocket.CLOSING).toBe(2);
+        expect(DurableWebSocket.CLOSED).toBe(3);
+        const ws = makeSocket();
+        expect(ws.CONNECTING).toBe(0);
+        expect(ws.OPEN).toBe(1);
+        expect(ws.CLOSING).toBe(2);
+        expect(ws.CLOSED).toBe(3);
+        ws.close();
+    });
+
+    it("is exported under the WebSocket alias", () => {
+        expect(CompatWS).toBe(DurableWebSocket);
+    });
+
+    it("connects on construction and fires open both ways", async () => {
+        const ws = makeSocket();
+        expect(ws.readyState).toBe(DurableWebSocket.CONNECTING);
+
+        const viaProp = vi.fn();
+        const viaListener = vi.fn();
+        ws.onopen = viaProp;
+        ws.addEventListener("open", viaListener);
+
+        await server.connected;
+        await vi.waitFor(() => {
+            expect(ws.readyState).toBe(DurableWebSocket.OPEN);
+        });
+        expect(viaProp).toHaveBeenCalledTimes(1);
+        expect(viaListener).toHaveBeenCalledTimes(1);
+        expect(viaProp.mock.calls[0][0]).toBeInstanceOf(Event);
+        ws.close();
+    });
+
+    it("is wire-faithful: no JSON codec in either direction", async () => {
+        const ws = makeSocket();
+        const received: unknown[] = [];
+        ws.onmessage = (event) => received.push(event.data);
+        await server.connected;
+
+        ws.send('{"already":"json"}');
+        await expect(server).toReceiveMessage('{"already":"json"}');
+
+        server.send('{"type":"chat"}');
+        await vi.waitFor(() => {
+            // The raw string — not a parsed object.
+            expect(received).toEqual(['{"type":"chat"}']);
+        });
+        ws.close();
+    });
+
+    it("queues sends while connecting and flushes on open", async () => {
+        const ws = makeSocket();
+        ws.send("early"); // native would throw InvalidStateError; we queue
+        await server.connected;
+        await expect(server).toReceiveMessage("early");
+        ws.close();
+    });
+
+    it("close() walks CLOSING → CLOSED and fires a CloseEvent", async () => {
+        const ws = makeSocket();
+        await server.connected;
+        await vi.waitFor(() => {
+            expect(ws.readyState).toBe(DurableWebSocket.OPEN);
+        });
+
+        const closes: CloseEvent[] = [];
+        ws.onclose = (event) => closes.push(event);
+        ws.close();
+        expect(ws.readyState).toBe(DurableWebSocket.CLOSING);
+        await vi.waitFor(() => {
+            expect(ws.readyState).toBe(DurableWebSocket.CLOSED);
+        });
+        expect(closes).toHaveLength(1);
+        expect(typeof closes[0].code).toBe("number");
+    });
+
+    it("send after close is silently discarded (native fidelity)", async () => {
+        const ws = makeSocket();
+        await server.connected;
+        ws.close();
+        await vi.waitFor(() => {
+            expect(ws.readyState).toBe(DurableWebSocket.CLOSED);
+        });
+        expect(() => ws.send("late")).not.toThrow();
+    });
+
+    it("readyState returns to CONNECTING during automatic reconnection", async () => {
+        const ws = new DurableWebSocket(URL, undefined, {
+            reconnect: { baseDelay: 30_000, jitter: false }
+        });
+        await server.connected;
+        await vi.waitFor(() => {
+            expect(ws.readyState).toBe(DurableWebSocket.OPEN);
+        });
+
+        server.close(); // unexpected → reconnecting (long backoff)
+        await vi.waitFor(() => {
+            expect(ws.client.state).toBe("reconnecting");
+        });
+        // The documented deviation: a native socket can never do this.
+        expect(ws.readyState).toBe(DurableWebSocket.CONNECTING);
+        ws.close();
+    });
+
+    it("recovers transparently and keeps delivering", async () => {
+        const ws = new DurableWebSocket(URL, undefined, {
+            reconnect: { baseDelay: 10, jitter: false }
+        });
+        const received: unknown[] = [];
+        ws.addEventListener("message", (event) => {
+            received.push((event as MessageEvent).data);
+        });
+        await server.connected;
+
+        server.close();
+        WS.clean();
+        server = new WS(URL);
+
+        await vi.waitFor(
+            () => {
+                expect(ws.readyState).toBe(DurableWebSocket.OPEN);
+            },
+            { timeout: 2000 }
+        );
+        server.send("after-recovery");
+        await vi.waitFor(() => {
+            expect(received).toEqual(["after-recovery"]);
+        });
+        ws.close();
+    });
+
+    it("exposes the underlying client as the escape hatch", async () => {
+        const ws = makeSocket();
+        expect(ws.client.state).toBe("connecting");
+        await server.connected;
+        await vi.waitFor(() => {
+            expect(ws.client.getState().state).toBe("open");
+        });
+        ws.close();
+    });
+
+    it("converts Blob frames when binaryType is set after construction", async () => {
+        const ws = makeSocket();
+        ws.binaryType = "arraybuffer";
+        expect(ws.binaryType).toBe("arraybuffer");
+        const received: unknown[] = [];
+        ws.onmessage = (event) => received.push(event.data);
+        await server.connected;
+
+        const blob = new Blob(["bytes"]);
+        server.send(blob as unknown as string);
+        await vi.waitFor(() => {
+            expect(received).toHaveLength(1);
+        });
+        expect(received[0]).toBeInstanceOf(ArrayBuffer);
+        ws.close();
+    });
+});

--- a/packages/durablews/tsup.config.ts
+++ b/packages/durablews/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-    entry: ["src/index.ts", "src/vue.ts", "src/react.ts"],
+    entry: ["src/index.ts", "src/vue.ts", "src/react.ts", "src/compat.ts"],
     format: ["esm", "cjs"],
     dts: true,
     clean: true,

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -625,17 +625,22 @@ stops moving; release is last.
   providers, production miles), and **`llms.txt`** (hand-written, in
   `docs/public/`) for AI-assistant discovery. Also corrects §2.1's false
   "partysocket does not queue" claim (see the correction note there).
-- ⬜ **Slice 5 — `durablews/compat` (decision: build, with scoped fidelity).**
-  A drop-in `WebSocket`-shaped class over core for two documented audiences:
-  app-code one-line migration (the `reconnecting-websocket`/`partysocket`
-  crowd) and **`webSocketImpl`-style injection points** in existing libraries
-  (graphql-ws, y-websocket, realtime SDKs) — durability injected into whole
-  ecosystems that never learn durablews exists. Fidelity is deliberately
-  scoped to those two use cases with a published "known deviations" table
-  (e.g. `readyState` re-entering `CONNECTING` across reconnects, which the
-  spec's one-shot lifecycle forbids) — no quixotic spec-perfection, since a
-  subtly unfaithful impostor is worse than a documented one. Migration docs
-  page included.
+- ✅ **Slice 5 — `durablews/compat` (decision: build, with scoped fidelity).**
+  `DurableWebSocket` (also exported as `WebSocket`) — an `EventTarget`-based,
+  `WebSocket`-shaped class over core for the two documented audiences:
+  app-code one-line migration and **`webSocketImpl`-style injection**
+  (graphql-ws, y-websocket examples in the docs). Wire-faithful by
+  construction (identity codec — no JSON); Level0 (`onopen`/…) + Level2
+  (`addEventListener`) event styles; constructor third arg takes the
+  durablews config; the full client is exposed as `.client` (escape hatch to
+  `drop`/`reconnecting`/middleware). The **known-deviations table** lives on
+  the docs page (readyState re-enters `CONNECTING` across reconnects;
+  send-while-connecting queues; `protocol`/`extensions`/`bufferedAmount`
+  stubs; post-construction `binaryType` emulated via order-preserving Blob
+  conversion with a `FileReader` fallback for jsdom). Core gained one small
+  option in support: `binaryType`, applied to the socket on every
+  (re)connect — generally useful for binary protocols, not compat-specific.
+  E2e: the compat class survives a server drop in real Chromium.
 - ⬜ **Slice 6 — Cross-runtime e2e + distribution assets.** Node-as-client +
   Deno/Bun e2e (closing §6's claim); size-limit budget enforced in CI + badge;
   runnable `examples/`.
@@ -657,6 +662,17 @@ stops moving; release is last.
   `error`/`statechange`). Option names refined as each seam lands.
 - Whether channels are the only plugin-shaped feature (which would let us drop
   the umbrella "plugin" concept from the public vocabulary).
+- **AsyncAPI / OpenAPI integration (v2.x idea — recorded 2026-06-09, not
+  scheduled).** OpenAPI itself cannot describe WebSocket message flows — it
+  is an HTTP request/response spec; the async-world equivalent is
+  **AsyncAPI**, which has first-class WebSocket bindings (channels, message
+  schemas). Core already has the right seams and needs nothing added:
+  `schema` accepts any Standard Schema, so an AsyncAPI document's message
+  schemas (JSON Schema) can validate inbound traffic today through a
+  json-schema→Standard-Schema adapter. The product-shaped idea is
+  **codegen** — a `durablews-asyncapi` tool that generates a typed client
+  (channel definitions, message unions, validators) from an AsyncAPI
+  document. Post-2.0 growth item, alongside the socket.io codec.
 - ~~`connect()` can never settle under default config.~~ **Settled in M3
   slice 1: pending-forever is by design.** Under `maxRetries: Infinity` the
   client is *still working* — a rejection would be a lie, and a built-in


### PR DESCRIPTION
## Summary

M4 slice 5 — `durablews/compat`, built per the settled scoped-fidelity decision. `DurableWebSocket` (also exported as `WebSocket`) is an `EventTarget`-based, `WebSocket`-shaped class over the durable core, for the two documented audiences: **one-line app-code migration** and **`webSocketImpl`-style injection** (graphql-ws and y-websocket examples on the docs page).

## Fidelity, scoped and documented

- **Wire-faithful by construction**: identity codec — no JSON in either direction. Byte in, byte out.
- Level0 (`onopen`/`onmessage`/…) **and** Level2 (`addEventListener`) event styles; native constants static and per-instance; `CloseEvent` re-dispatch with a structural fallback for runtimes without the global.
- **The known-deviations table ships on the docs page** — the flagship one being `readyState` re-entering `CONNECTING` across reconnects (a native socket is one-shot; this is the entire point). Send-while-connecting **queues** (native throws); send-after-close silently discards (native-matched); `protocol`/`extensions`/`bufferedAmount` are documented stubs.
- `binaryType` works two ways: pass it in options (core gained a `binaryType` config applied per (re)connect — generally useful for binary protocols, not compat-specific) or assign post-construction, which is **emulated** via order-preserving Blob→ArrayBuffer conversion (`FileReader` fallback because jsdom — a real environment for users' own tests — ships `Blob` without `arrayBuffer()`), with a synchronous fast path so native event ordering holds whenever no conversion is pending.
- The full client is exposed as `.client` — the escape hatch to `drop`/`reconnecting` events and middleware.

## Also in this PR

RFC §9 records the **AsyncAPI/OpenAPI idea** from today's discussion as a v2.x growth item (OpenAPI can't describe WS message flows; AsyncAPI is the async-world equivalent; core needs nothing — the product-shaped version is a `durablews-asyncapi` codegen tool).

## Tests

11 new integration tests (constants, both event styles, wire-fidelity both directions, queue-on-connecting, CLOSING→CLOSED walk, send-after-close, readyState-during-reconnect, transparent recovery, escape hatch, alias, Blob conversion) — **156 total** — plus an e2e where the compat class survives a server drop in real Chromium (**7 e2e total**). Comparison matrix row flipped to shipped.

M4: slices 1–5 ✅. Remaining: 6 (cross-runtime e2e + size budget + examples), 7 (2.0 release).