### PR TITLE
fix(release): drop the publish gate; enable manual runs (workflow_dispatch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,21 @@ jobs:
   release:
     name: Version or publish
     runs-on: ubuntu-latest
-    # Kill switch: set the NPM_PUBLISH_ENABLED repo variable to "true".
-    if: github.repository == 'imnsco/DurableWS' && vars.NPM_PUBLISH_ENABLED == 'true'
+    if: github.repository == 'imnsco/DurableWS'
     # Must match the npm Trusted Publisher registration (repo + workflow
     # file + environment); the OIDC token carries the environment claim.
     environment: production
     steps:
+      # Kill switch: NPM_PUBLISH_ENABLED lives in the production
+      # *environment*, so it is only visible to steps (a job-level `if` is
+      # evaluated before the environment resolves) — hence the per-step gate.
       - uses: actions/checkout@v4
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
       - name: Install pnpm
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: pnpm/action-setup@v4
       - name: Setup Node
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -34,13 +39,16 @@ jobs:
       # authenticates via the runner's OIDC token and attaches provenance
       # automatically.
       - name: Update npm for OIDC trusted publishing
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: npm install -g npm@latest
       - name: Install dependencies
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: pnpm install --frozen-lockfile
       # With pending changesets: opens/updates the "Version Packages" PR.
       # Without (i.e. the Version PR just merged): builds and publishes to
       # npm under the dist-tag changesets derives from pre mode ("alpha").
       - name: Version PR or publish
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: changesets/action@v1
         with:
           version: pnpm release:version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   push:
     branches: [main]
+  # Manual runs from the Actions UI (e.g. to open/refresh the Version
+  # Packages PR without waiting for a merge).
+  workflow_dispatch:
 
 concurrency: release-${{ github.ref }}
 
@@ -18,18 +21,17 @@ jobs:
     if: github.repository == 'imnsco/DurableWS'
     # Must match the npm Trusted Publisher registration (repo + workflow
     # file + environment); the OIDC token carries the environment claim.
+    #
+    # No publish gate needed: with changesets pending this only maintains
+    # the "Version Packages" PR — the deliberate human act of merging that
+    # PR is what publishes. Emergency stop: Actions UI → Release →
+    # "Disable workflow".
     environment: production
     steps:
-      # Kill switch: NPM_PUBLISH_ENABLED lives in the production
-      # *environment*, so it is only visible to steps (a job-level `if` is
-      # evaluated before the environment resolves) — hence the per-step gate.
       - uses: actions/checkout@v4
-        if: vars.NPM_PUBLISH_ENABLED == 'true'
       - name: Install pnpm
-        if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: pnpm/action-setup@v4
       - name: Setup Node
-        if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -39,16 +41,13 @@ jobs:
       # authenticates via the runner's OIDC token and attaches provenance
       # automatically.
       - name: Update npm for OIDC trusted publishing
-        if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: npm install -g npm@latest
       - name: Install dependencies
-        if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: pnpm install --frozen-lockfile
       # With pending changesets: opens/updates the "Version Packages" PR.
       # Without (i.e. the Version PR just merged): builds and publishes to
       # npm under the dist-tag changesets derives from pre mode ("alpha").
       - name: Version PR or publish
-        if: vars.NPM_PUBLISH_ENABLED == 'true'
         uses: changesets/action@v1
         with:
           version: pnpm release:version


### PR DESCRIPTION
## Summary

Two release-workflow fixes, superseding the first commit on this branch:

1. **The `NPM_PUBLISH_ENABLED` gate is gone.** It was doubly wrong: created in the `production` environment it was invisible to the job-level `if` (which evaluates before the environment resolves — why the run skipped), and more fundamentally it was redundant. The push-to-main trigger only *maintains the Version Packages PR*; the actual npm publish happens when a human **merges that PR** — that's the deliberate step. Emergency stop: Actions UI → Release → "Disable workflow" (GitHub's native kill switch). The env variable can be deleted.
2. **`workflow_dispatch` added** — the workflow can now be run manually from the Actions UI, e.g. to open/refresh the Version PR without waiting for a merge.

After this merges, the release run on that push should open the **Version Packages PR** (`durablews@2.0.0-alpha.1`). Merging it publishes via OIDC trusted publishing with provenance.