### PR TITLE
fix(changesets): un-consume the alpha release-notes changeset

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,5 +5,5 @@
         "docs": "0.0.0",
         "durablews": "2.0.0-alpha.0"
     },
-    "changesets": ["young-llamas-launch"]
+    "changesets": []
 }


### PR DESCRIPTION
## Summary

Root-cause fix for the surprise in the first release run. `pre.json` was committed with `young-llamas-launch` already in its consumed list — my error while validating `release:version` locally in #29: the dry-run mutated `pre.json` *before it was tracked*, so `git checkout -- .` didn't revert it. The changesets action filters consumed changesets, saw none pending, and took the **publish path** — `durablews@2.0.0-alpha.0` went straight to npm on merge instead of via a Version Packages PR.

**The published artifact is correct** (current `main` = slices 1–5, `alpha` dist-tag, OIDC trusted publishing + provenance verified working end-to-end). What was skipped: the Version-PR human step and the CHANGELOG entry.

This resets `pre.json`'s consumed list so the pending release-notes changeset is visible again. The release run after this merges will open the **Version Packages PR** (`2.0.0-alpha.1`) — merging that publishes the same content plus the proper CHANGELOG, and every future release flows through the Version PR as designed.