### PR TITLE
docs: drop the 'X of Y' framing; refresh homepage and READMEs to shipped reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # DurableWS
 
-> A resilient, modern, zero-dependency WebSocket **client** for TypeScript — "the Hono of WebSockets." Built on the standard `WebSocket`, durable by default, and the same in every modern runtime (browser, Node ≥22, Deno, Bun, edge).
+> The WebSocket client that survives the real world — automatic reconnection, bounded queueing, and typed messages. Zero dependencies, built on the standard `WebSocket`, the same in every modern runtime (browser, Node ≥22, Deno, Bun, edge).
 
-> ⚠️ **v2 is under active development.** See [RFC 0001](rfcs/0001-v2-architecture.md) for the architecture and a live status tracker. The current npm release (`1.x`) predates this redesign.
+> ⚠️ **v2 is in alpha** (`npm install durablews@alpha`). See [RFC 0001](rfcs/0001-v2-architecture.md) for the architecture and a live status tracker, and **[durablews.imns.co](https://durablews.imns.co)** for the docs.
 
 The published library lives in **[`packages/durablews`](packages/durablews)** — see its [README](packages/durablews/README.md) for usage, the feature status, and requirements.
 
@@ -16,8 +16,8 @@ This is a pnpm monorepo.
 
 ```
 packages/durablews   the published library
-docs/                documentation
-  rfc/               design RFCs (source of truth + live status)
+docs/                the documentation site (Astro + Starlight → durablews.imns.co)
+rfcs/                design RFCs (source of truth + live status)
 ```
 
 ## Development

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -3,11 +3,15 @@ title: DurableWS
 description: A resilient, zero-dependency WebSocket client for TypeScript — durable by default.
 template: splash
 hero:
-  tagline: The Hono of WebSockets — tiny, ergonomic, built on the standard WebSocket, and durable by default.
+  tagline: The WebSocket client that survives the real world — automatic reconnection, bounded queueing, and typed messages. Zero dependencies, every modern runtime.
   actions:
     - text: Get started
       link: /getting-started/
       icon: right-arrow
+    - text: Why DurableWS?
+      link: /comparison/
+      icon: information
+      variant: secondary
     - text: View on GitHub
       link: https://github.com/imnsco/DurableWS
       icon: external
@@ -16,26 +20,41 @@ hero:
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-:::caution[Alpha]
-v2 (`2.0.0-alpha`) is under active development. The API is changing and several
-headline features below are still being built — see the
-[architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
-for the design and live status.
+:::note[Alpha]
+v2 is published as `durablews@alpha`. The features below are built and tested
+(unit, integration, real-browser e2e); the API may still shift before 2.0 —
+the [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
+tracks design and status.
 :::
 
 <CardGrid stagger>
 	<Card title="Durable by default" icon="random">
-		Automatic reconnection, message queueing, and idle detection — designed
-		to work out of the box, no wiring required.
+		Automatic reconnection with full-jitter backoff and bounded message
+		queueing — on out of the box. Opt-in heartbeat closes quietly-dead
+		links. Every dropped message is observable; nothing is silently lost.
+	</Card>
+	<Card title="Typed end to end" icon="seti:typescript">
+		Pass any [Standard Schema](https://standardschema.dev) (zod, valibot,
+		arktype, …) and inbound messages are inferred **and**
+		runtime-validated before your handlers see them.
+	</Card>
+	<Card title="Vue & React in the box" icon="laptop">
+		A [composable](/frameworks/vue/) and a [hook](/frameworks/react/) as
+		subpath exports with optional peers — reactive connection state,
+		automatic cleanup, one install.
+	</Card>
+	<Card title="Drop-in compatible" icon="approve-check">
+		[`durablews/compat`](/guides/compat/) is a `WebSocket`-shaped class:
+		swap it into existing code or inject it as a library's
+		`webSocketImpl` — with a published known-deviations table.
 	</Card>
 	<Card title="Zero dependencies" icon="rocket">
-		Built on the standard global `WebSocket`. No `ws`, no bloat. Works in
-		browsers, Node ≥22, Deno, Bun, and the edge.
+		Built on the standard global `WebSocket`. No `ws`, no bloat. Browsers,
+		Node ≥22, Deno, Bun, and the edge.
 	</Card>
-	<Card title="Extensible" icon="puzzle">
-		A middleware + codec pipeline for custom wire formats, auth, and more.
-	</Card>
-	<Card title="TypeScript-first" icon="open-book">
-		Fully typed, dual ESM + CJS, with accurate type resolution.
+	<Card title="Extensible where it counts" icon="puzzle">
+		[Middleware](/guides/middleware/) in both directions (async-safe,
+		auth-ready) and a pluggable [codec](/guides/codecs/) for custom wire
+		formats.
 	</Card>
 </CardGrid>

--- a/packages/durablews/README.md
+++ b/packages/durablews/README.md
@@ -1,44 +1,48 @@
 # DurableWS
 
-> A resilient, modern, zero-dependency WebSocket **client** for TypeScript — built on the standard `WebSocket`, durable by default, and the same in every modern runtime.
+> The WebSocket client that survives the real world — automatic reconnection,
+> bounded queueing, and typed messages. Zero dependencies, every modern
+> runtime, durable by default.
 
-> ⚠️ **v2 is under active development (`2.0.0-alpha`).** The API is changing and several headline features below are still being built. See the [v2 architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md) for the design and live status. The current npm release (`1.x`) predates this redesign.
+> ⚠️ **v2 is in alpha** (`npm install durablews@alpha`). The features below
+> are built and tested (unit, integration, real-browser e2e); the API may
+> still shift before 2.0. The
+> [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
+> tracks design and status. The `1.x` release predates this rewrite — don't
+> use it.
 
-DurableWS aims to be "the Hono of WebSockets": tiny, ergonomic, Web-Standards-based, and **durable by default** — automatic reconnection, message queueing, and idle detection out of the box — with a middleware + codec pipeline for extensibility (custom wire formats, auth, a socket.io-compatibility layer, and more).
+## What you get
 
-## Status
-
-DurableWS v2 is being built in the open. To be accurate about what exists today vs. what's planned:
-
-**Working now**
-
-- Connect / send / close and incoming-message handling over the standard `WebSocket`
-- Event subscriptions (`on` / `off`)
-- A middleware pipeline (`use`)
-- Built-in JSON-safe message parsing and a ping/pong middleware
-
-**Planned for v2 (not yet implemented)**
-
-- Automatic reconnection with exponential backoff
-- Message queueing while disconnected, flushed on reconnect
-- Idle detection
-- A typed connection state machine
-- Pluggable codecs (msgpack, socket.io framing, …) and an authentication helper
-- Channels / subscriptions
-
-Until these land, treat the durability features as a roadmap, not a guarantee.
+- **Automatic reconnection, on by default** — full-jitter exponential
+  backoff, unlimited retries, a `shouldReconnect` veto, and `reconnecting`
+  events for your UI.
+- **Message queueing while disconnected, on by default** — bounded,
+  drop-oldest, flushed in order on open. Every dropped message fires a `drop`
+  event; nothing is silently lost.
+- **Opt-in heartbeat / idle detection** — quietly-dead links are closed (code
+  `4408`) and recovered through the normal reconnect machinery.
+- **Typed + validated messages** — pass any
+  [Standard Schema](https://standardschema.dev) (zod, valibot, arktype, …)
+  and inbound messages are type-inferred *and* runtime-validated.
+- **Middleware, inbound and outbound** — an onion pipeline with async-safe,
+  ordered outbound execution (auth/token-refresh ready).
+- **Pluggable codec** — JSON by default; swap in msgpack or anything else.
+- **Vue & React bindings in the box** — `durablews/vue` (composable) and
+  `durablews/react` (hook); the frameworks are optional peers.
+- **A drop-in `WebSocket` class** — `durablews/compat` for one-line migration
+  or `webSocketImpl` injection, with a published known-deviations table.
+- **Zero runtime dependencies**, built on the standard global `WebSocket`.
 
 ## Requirements
 
-DurableWS targets the **standard global `WebSocket`** and ships **zero runtime dependencies**. That means:
-
-- **Node.js ≥ 22** — the first release where the global `WebSocket` is available unflagged. (There is no `ws` dependency, by design.)
-- Any modern runtime with a global `WebSocket`: current browsers, Deno, Bun, and Cloudflare Workers.
+- **Node.js ≥ 22** — the first release where the global `WebSocket` is
+  available unflagged. (There is no `ws` dependency, by design.)
+- Any modern runtime with a global `WebSocket`: current browsers, Deno, Bun,
+  and Cloudflare Workers.
 
 ## Installation
 
 ```bash
-# v2 is not yet published; once the alpha ships it will be:
 npm install durablews@alpha
 ```
 
@@ -60,10 +64,24 @@ client.send({ type: "hello", message: "world" });
 client.close();
 ```
 
+Typed and validated, with any Standard Schema:
+
+```ts
+import { z } from "zod";
+
+const Message = z.object({ type: z.string(), body: z.string() });
+const client = defineClient({ url, schema: Message });
+
+client.on("message", (msg) => {
+    // msg: { type: string; body: string } — validated at runtime
+});
+```
+
 ## Documentation
 
-- [v2 architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
-- A full documentation site (Astro + Starlight) is coming as part of v2.
+**[durablews.imns.co](https://durablews.imns.co)** — getting started, guides
+(durability tuning, middleware, codecs, drop-in compat), framework pages, the
+API reference, and an honest comparison with the alternatives.
 
 ## Contributing
 

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -673,6 +673,19 @@ stops moving; release is last.
   **codegen** — a `durablews-asyncapi` tool that generates a typed client
   (channel definitions, message unions, validators) from an AsyncAPI
   document. Post-2.0 growth item, alongside the socket.io codec.
+- **OpenTelemetry (v2.x idea — recorded 2026-06-10, not scheduled).** Core
+  needs nothing: the existing seams already expose every signal an
+  instrumentation wants — middleware (both directions) for message
+  spans/counts, `subscribe()`/`getState()` for state and queue-depth
+  metrics, and the event vocabulary (`reconnecting`, `drop`, `error`,
+  close code 4408) for the durability story. The product-shaped version is
+  a small `durablews/otel` subpath (a middleware + subscriber pack over
+  `@opentelemetry/api` as an optional peer, like the framework bindings).
+  Honest caveats before scheduling it: OTel has **no stable semantic
+  conventions for WebSockets** (we'd be inventing attribute names), and
+  browser-side OTel adoption is thin — the audience is Node/edge
+  service-to-service clients, real but a minority. Decide on demand;
+  userland can build it today against the public seams.
 - ~~`connect()` can never settle under default config.~~ **Settled in M3
   slice 1: pending-forever is by design.** Under `maxRetries: Infinity` the
   client is *still working* — a rejection would be a lie, and a built-in


### PR DESCRIPTION
## Summary

Positioning fix per today's discussion, plus a staleness sweep the fix surfaced.

- **"The Hono of WebSockets" is gone from every public surface** — homepage hero, root README, and the package README (the npm page). It survives only in the RFC, where it's a design compass, not marketing. New public tagline leads with what the library does: *"The WebSocket client that survives the real world — automatic reconnection, bounded queueing, and typed messages."*
- **Homepage refresh**: a "Why DurableWS?" hero action, the alpha caution rewritten (the features are built and tested — the old text said they were "still being built"), and six feature cards matching shipped reality (durability, typed messages, Vue/React in the box, drop-in compat, zero deps, middleware/codec).
- **Package README rewritten** — it still listed reconnection/queueing/heartbeat under "Planned (not yet implemented)" and said the docs site was "coming". This is the npm landing page and ships with the next alpha publish.
- **RFC §9**: OpenTelemetry recorded as an unscheduled v2.x idea next to AsyncAPI — core needs nothing (the seams expose every signal); a `durablews/otel` subpath is the product shape if demand appears; caveats: no OTel WebSocket semantic conventions exist, browser OTel is thin.