### PR TITLE
fix(ci): auto-trigger required checks on the Version Packages PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Dispatched by the release workflow against changeset-release/main: pushes
+  # made with GITHUB_TOKEN never trigger pull_request workflows (GitHub's
+  # recursion guard), but workflow_dispatch is exempt — so the Version
+  # Packages PR gets its required checks this way.
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write # npm trusted publishing (OIDC) + provenance
+  actions: write # dispatch CI at the Version PR branch (see below)
 
 jobs:
   release:
@@ -48,6 +49,7 @@ jobs:
       # Without (i.e. the Version PR just merged): builds and publishes to
       # npm under the dist-tag changesets derives from pre mode ("alpha").
       - name: Version PR or publish
+        id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm release:version
@@ -56,3 +58,12 @@ jobs:
           title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The changesets action pushes changeset-release/main with GITHUB_TOKEN,
+      # whose events never trigger other workflows (recursion guard) — so the
+      # Version PR's required checks would sit "expected" forever. The guard
+      # exempts workflow_dispatch: kick CI at the branch explicitly.
+      - name: Trigger CI on the Version PR
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        run: gh workflow run ci.yml --ref changeset-release/main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Permanent fix for the stuck Version PR (#35 needed a manual close/reopen to get its checks).

**Cause:** the changesets action pushes `changeset-release/main` using the workflow's `GITHUB_TOKEN`, and GitHub suppresses all workflow triggers for `GITHUB_TOKEN` events (recursion prevention) — so the `pull_request` CI never fired and the ruleset's required checks sat "expected" forever.

**Fix without a PAT:** the recursion guard explicitly exempts `workflow_dispatch`. After the changesets step, the release workflow now dispatches `ci.yml` at `changeset-release/main` (new `actions: write` permission, gated on the action's `hasChangesets` output); `ci.yml` gains a `workflow_dispatch` trigger. The dispatched run's check runs land on the branch's head commit — the same SHA the PR's required checks are evaluated against — so the Version PR arrives mergeable. Every subsequent push to `main` that rebuilds the Version PR branch re-dispatches, keeping checks current with the new head.

**Verification:** provable at the next Version PR (i.e. the first changeset after this merges). If the dispatched checks turn out not to satisfy the ruleset, the fallback is a fine-grained PAT for the changesets action — but the dispatch route should make that unnecessary.