### PR TITLE
feat: cross-runtime e2e, size budgets, runnable examples (M4 slice 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,118 @@ jobs:
         run: pnpm -F durablews e2e:install
       - name: Run browser e2e
         run: pnpm -F durablews e2e
+
+  size:
+    name: Size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm -F durablews build
+      - name: Enforce bundle-size budgets
+        run: pnpm -F durablews size
+
+  e2e-node:
+    name: E2E (Node)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm -F durablews build
+      - name: Run runtime smoke (Node 22, the support floor)
+        working-directory: packages/durablews
+        run: |
+          node e2e/echo-standalone.mjs &
+          sleep 1
+          WS_PORT=8787 node e2e/runtime-smoke.mjs
+
+  e2e-deno:
+    name: E2E (Deno)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm -F durablews build
+      - name: Run runtime smoke (Deno)
+        working-directory: packages/durablews
+        run: |
+          node e2e/echo-standalone.mjs &
+          sleep 1
+          WS_PORT=8787 deno run --allow-net --allow-read --allow-env e2e/runtime-smoke.mjs
+
+  e2e-bun:
+    name: E2E (Bun)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm -F durablews build
+      - name: Run runtime smoke (Bun)
+        working-directory: packages/durablews
+        run: |
+          node e2e/echo-standalone.mjs &
+          sleep 1
+          WS_PORT=8787 bun e2e/runtime-smoke.mjs
+
+  examples:
+    name: Examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build the library
+        run: pnpm -F durablews build
+      - name: Build every example
+        run: pnpm -F "example-*" build

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # DurableWS
 
+[![npm](https://img.shields.io/npm/v/durablews/alpha?label=npm%40alpha)](https://www.npmjs.com/package/durablews)
+[![CI](https://github.com/imnsco/DurableWS/actions/workflows/ci.yml/badge.svg)](https://github.com/imnsco/DurableWS/actions/workflows/ci.yml)
+[![bundle size](https://img.shields.io/badge/core-%E2%89%A4%203%20KB%20brotli%20(CI--enforced)-blue)](packages/durablews/package.json)
+[![license](https://img.shields.io/badge/license-MPL--2.0-green)](LICENSE)
+
 > The WebSocket client that survives the real world — automatic reconnection, bounded queueing, and typed messages. Zero dependencies, built on the standard `WebSocket`, the same in every modern runtime (browser, Node ≥22, Deno, Bun, edge).
 
 > ⚠️ **v2 is in alpha** (`npm install durablews@alpha`). See [RFC 0001](rfcs/0001-v2-architecture.md) for the architecture and a live status tracker, and **[durablews.imns.co](https://durablews.imns.co)** for the docs.
 
 The published library lives in **[`packages/durablews`](packages/durablews)** — see its [README](packages/durablews/README.md) for usage, the feature status, and requirements.
+
+## Examples
+
+Runnable, in [`examples/`](examples/):
+
+- **[resilience-playground](examples/resilience-playground/)** — sabotage the server from the UI and watch the state machine, retry counter, and queue survive you. The flagship demo.
+- **[chat](examples/chat/)** — presence + typing indicators, implemented twice (Vue composable, React hook) against one server and one zod schema.
+- **[collab-notepad](examples/collab-notepad/)** — a raw-`WebSocket` collaborative editor made durable by swapping one import (`durablews/compat`).
 
 ## Why
 

--- a/biome.json
+++ b/biome.json
@@ -30,5 +30,18 @@
             "semicolons": "always",
             "trailingCommas": "none"
         }
-    }
+    },
+    "overrides": [
+        {
+            "includes": ["**/*.vue"],
+            "linter": {
+                "rules": {
+                    "correctness": {
+                        "noUnusedVariables": "off",
+                        "useHookAtTopLevel": "off"
+                    }
+                }
+            }
+        }
+    ]
 }

--- a/docs/src/content/docs/guides/compat.md
+++ b/docs/src/content/docs/guides/compat.md
@@ -47,6 +47,28 @@ const provider = new WebsocketProvider(url, room, doc, {
 });
 ```
 
+:::caution[The layering rule: one reconnector per stack]
+Libraries with **stateful sync protocols** — y-websocket, graphql-ws —
+implement their *own* reconnection, because they must redo a handshake on
+every new connection. Injecting a socket that also reconnects puts two
+recovery layers in a fight (the library abandons the socket on `close` while
+the socket revives itself — zombie connections). When the consuming library
+reconnects, hand it a wrapper with ours off:
+
+```ts
+class PipeSocket extends DurableWebSocket {
+    constructor(url: string | URL, protocols?: string | string[]) {
+        super(url, protocols, { reconnect: false });
+    }
+}
+```
+
+Compat's sweet spot is code that treats the socket as a **plain pipe** —
+hand-rolled WebSocket code, thin SDKs without recovery logic — where the
+one-line swap delivers the full durability story. See the
+[collab-notepad example](https://github.com/imnsco/DurableWS/tree/main/examples/collab-notepad).
+:::
+
 ## Tuning the durability
 
 The third constructor argument takes the durablews config (everything except

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -1,0 +1,30 @@
+# Chat — Vue and React, one server
+
+The bread-and-butter demo: a broadcast chat with presence and typing
+indicators, implemented twice — once with the Vue composable, once with the
+React hook — against the same server and the same zod schema. Open both side
+by side and talk to yourself.
+
+```bash
+pnpm install && pnpm -F durablews build   # once, from the repo root
+
+pnpm -F example-chat dev:server   # terminal 1 — ws://localhost:8789
+pnpm -F example-chat dev:vue      # terminal 2 — http://localhost:5174
+pnpm -F example-chat dev:react    # terminal 3 — http://localhost:5175
+```
+
+What it shows:
+
+- **`useWebSocket` in both idioms** — config-owned client, auto-connect,
+  cleanup on unmount, reactive `state`.
+- **One zod schema, both clients** ([shared/schema.ts](shared/schema.ts)):
+  message types are *inferred* and every inbound frame is runtime-validated
+  before a handler sees it.
+- **History is app state** — `lastMessage` holds only the latest; each client
+  accumulates its own list via `client.on("message", …)`, the boundary
+  DurableWS deliberately doesn't cross.
+- **Typing indicators as a call-site policy** (throttle in front of `send()`),
+  per the middleware guide's layering rule.
+- **Durability for free**: kill the server mid-conversation (`Ctrl-C`,
+  restart it) — both clients walk through `reconnecting` and resume; anything
+  sent while down queues and flushes.

--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "example-chat",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev:server": "node server.mjs",
+        "dev:vue": "vite vue --port 5174",
+        "dev:react": "vite react --port 5175",
+        "build": "vite build vue && vite build react"
+    },
+    "dependencies": {
+        "durablews": "workspace:*",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "vue": "^3.5.35",
+        "zod": "^3.25.0"
+    },
+    "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.7.0",
+        "@vitejs/plugin-vue": "^5.2.4",
+        "typescript": "^5.9.3",
+        "vite": "^6.3.5",
+        "ws": "^8.21.0"
+    }
+}

--- a/examples/chat/react/index.html
+++ b/examples/chat/react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>DurableWS chat — React</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/examples/chat/react/src/App.tsx
+++ b/examples/chat/react/src/App.tsx
@@ -1,0 +1,98 @@
+import { useWebSocket } from "durablews/react";
+import { useEffect, useRef, useState } from "react";
+import {
+    CHAT_URL,
+    type ServerMessage,
+    ServerMessage as schema
+} from "../../shared/schema";
+
+const name = `react-${Math.floor(Math.random() * 1000)}`;
+
+type ChatLine = Extract<ServerMessage, { type: "chat" }>;
+
+export function App() {
+    // The hook owns the client: connects on mount, closes on unmount. The
+    // zod schema types every message AND runtime-validates it.
+    const { state, send, client } = useWebSocket({ url: CHAT_URL, schema });
+
+    const [messages, setMessages] = useState<ChatLine[]>([]);
+    const [presence, setPresence] = useState(0);
+    const [typing, setTyping] = useState("");
+    const typingTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+    // History is app state — subscribe to every message on the client.
+    useEffect(() => {
+        return client.on("message", (msg) => {
+            if (msg.type === "chat") {
+                setMessages((prior) => [...prior.slice(-49), msg]);
+                setTyping("");
+            } else if (msg.type === "presence") {
+                setPresence(msg.count);
+            } else if (msg.type === "typing" && msg.name !== name) {
+                setTyping(`${msg.name} is typing…`);
+                clearTimeout(typingTimer.current);
+                typingTimer.current = setTimeout(() => setTyping(""), 1500);
+            }
+        });
+    }, [client]);
+    useEffect(() => () => clearTimeout(typingTimer.current), []);
+
+    const [draft, setDraft] = useState("");
+    const lastTypingSentAt = useRef(0);
+    // Typing indicators via the call-site-throttle pattern from the
+    // middleware guide — not pipeline middleware.
+    function onInput(value: string) {
+        setDraft(value);
+        const now = Date.now();
+        if (now - lastTypingSentAt.current > 1000 && client.state === "open") {
+            lastTypingSentAt.current = now;
+            send({ type: "typing", name });
+        }
+    }
+    function submit(event: React.FormEvent) {
+        event.preventDefault();
+        if (!draft.trim()) {
+            return;
+        }
+        // Queues transparently if we happen to be reconnecting.
+        send({ type: "chat", name, body: draft });
+        setDraft("");
+    }
+
+    return (
+        <main
+            style={{
+                fontFamily: "system-ui",
+                maxWidth: 560,
+                margin: "2rem auto"
+            }}
+        >
+            <h1>
+                DurableWS chat <small>(React)</small>
+            </h1>
+            <p>
+                <b style={{ color: state === "open" ? "green" : "darkorange" }}>
+                    {state}
+                </b>{" "}
+                · {presence} online · you are {name}
+            </p>
+            <ul style={{ minHeight: 240, listStyle: "none", padding: 0 }}>
+                {messages.map((m) => (
+                    <li key={`${m.at}-${m.name}`}>
+                        <b>{m.name}:</b> {m.body}
+                    </li>
+                ))}
+            </ul>
+            <p style={{ opacity: 0.6, fontStyle: "italic" }}>{typing}&nbsp;</p>
+            <form onSubmit={submit}>
+                <input
+                    value={draft}
+                    onChange={(e) => onInput(e.target.value)}
+                    placeholder="Say something…"
+                    style={{ width: "70%", padding: "0.5rem" }}
+                />
+                <button type="submit">Send</button>
+            </form>
+        </main>
+    );
+}

--- a/examples/chat/react/src/main.tsx
+++ b/examples/chat/react/src/main.tsx
@@ -1,0 +1,7 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+const root = document.getElementById("root");
+if (root) {
+    createRoot(root).render(<App />);
+}

--- a/examples/chat/react/vite.config.ts
+++ b/examples/chat/react/vite.config.ts
@@ -1,0 +1,6 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+    plugins: [react()]
+});

--- a/examples/chat/server.mjs
+++ b/examples/chat/server.mjs
@@ -1,0 +1,45 @@
+import { WebSocketServer } from "ws";
+
+// A minimal broadcast chat server shared by the Vue and React clients.
+// Client → server: {type:"chat", name, body} | {type:"typing", name}
+// Server → client: the same, broadcast — plus {type:"presence", count}.
+const PORT = 8789;
+
+const wss = new WebSocketServer({ port: PORT }, () => {
+    console.log(`chat server: ws://localhost:${PORT}`);
+});
+
+function broadcast(message) {
+    const wire = JSON.stringify(message);
+    for (const socket of wss.clients) {
+        if (socket.readyState === socket.OPEN) {
+            socket.send(wire);
+        }
+    }
+}
+
+wss.on("connection", (socket) => {
+    broadcast({ type: "presence", count: wss.clients.size });
+    socket.on("close", () => {
+        broadcast({ type: "presence", count: wss.clients.size });
+    });
+    socket.on("message", (data) => {
+        let msg;
+        try {
+            msg = JSON.parse(data.toString());
+        } catch {
+            return;
+        }
+        if (msg.type === "chat" && msg.name && typeof msg.body === "string") {
+            broadcast({
+                type: "chat",
+                name: String(msg.name),
+                body: msg.body,
+                at: Date.now()
+            });
+        }
+        if (msg.type === "typing" && msg.name) {
+            broadcast({ type: "typing", name: String(msg.name) });
+        }
+    });
+});

--- a/examples/chat/shared/schema.ts
+++ b/examples/chat/shared/schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+// One Standard Schema validates every inbound message in BOTH clients —
+// pass it as `schema` and the message type is inferred, plus every frame is
+// runtime-validated before any handler sees it.
+export const ServerMessage = z.discriminatedUnion("type", [
+    z.object({
+        type: z.literal("chat"),
+        name: z.string(),
+        body: z.string(),
+        at: z.number()
+    }),
+    z.object({ type: z.literal("typing"), name: z.string() }),
+    z.object({ type: z.literal("presence"), count: z.number() })
+]);
+
+export type ServerMessage = z.infer<typeof ServerMessage>;
+
+export const CHAT_URL = "ws://localhost:8789";

--- a/examples/chat/vue/index.html
+++ b/examples/chat/vue/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>DurableWS chat — Vue</title>
+    </head>
+    <body>
+        <div id="app"></div>
+        <script type="module" src="/src/main.ts"></script>
+    </body>
+</html>

--- a/examples/chat/vue/src/App.vue
+++ b/examples/chat/vue/src/App.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { useWebSocket } from "durablews/vue";
+import { onUnmounted, ref, watch } from "vue";
+import {
+    CHAT_URL,
+    type ServerMessage,
+    ServerMessage as schema
+} from "../../shared/schema";
+
+const name = `vue-${Math.floor(Math.random() * 1000)}`;
+
+// The composable owns the client: connects now, closes on unmount. The zod
+// schema types lastMessage AND runtime-validates every inbound frame.
+const { state, lastMessage, send, client } = useWebSocket({
+    url: CHAT_URL,
+    schema
+});
+
+const messages = ref<Extract<ServerMessage, { type: "chat" }>[]>([]);
+const presence = ref(0);
+const typing = ref("");
+let typingTimer: ReturnType<typeof setTimeout> | undefined;
+
+// lastMessage keeps only the latest — accumulate history app-side, the
+// boundary DurableWS deliberately doesn't cross.
+watch(lastMessage, (msg) => {
+    if (!msg) {
+        return;
+    }
+    if (msg.type === "chat") {
+        messages.value = [...messages.value.slice(-49), msg];
+        typing.value = "";
+    } else if (msg.type === "presence") {
+        presence.value = msg.count;
+    } else if (msg.type === "typing" && msg.name !== name) {
+        typing.value = `${msg.name} is typing…`;
+        clearTimeout(typingTimer);
+        typingTimer = setTimeout(() => {
+            typing.value = "";
+        }, 1500);
+    }
+});
+onUnmounted(() => clearTimeout(typingTimer));
+
+const draft = ref("");
+// The debounce-in-front-of-send() pattern from the middleware guide:
+// typing indicators are a call-site policy, not pipeline middleware.
+let lastTypingSentAt = 0;
+function onInput() {
+    const now = Date.now();
+    if (now - lastTypingSentAt > 1000 && client.state === "open") {
+        lastTypingSentAt = now;
+        send({ type: "typing", name });
+    }
+}
+function submit() {
+    if (!draft.value.trim()) {
+        return;
+    }
+    // Queues transparently if we happen to be reconnecting.
+    send({ type: "chat", name, body: draft.value });
+    draft.value = "";
+}
+</script>
+
+<template>
+    <main>
+        <h1>DurableWS chat <small>(Vue)</small></h1>
+        <p>
+            <b :data-state="state">{{ state }}</b> · {{ presence }} online ·
+            you are {{ name }}
+        </p>
+        <ul>
+            <li v-for="m in messages" :key="m.at + m.name">
+                <b>{{ m.name }}:</b> {{ m.body }}
+            </li>
+        </ul>
+        <p class="typing">{{ typing }}&nbsp;</p>
+        <form @submit.prevent="submit">
+            <input
+                v-model="draft"
+                placeholder="Say something…"
+                @input="onInput"
+            />
+            <button type="submit">Send</button>
+        </form>
+    </main>
+</template>
+
+<style>
+body { font-family: system-ui, sans-serif; max-width: 560px; margin: 2rem auto; }
+ul { min-height: 240px; list-style: none; padding: 0; }
+.typing { opacity: 0.6; font-style: italic; }
+input { width: 70%; padding: 0.5rem; }
+b[data-state="open"] { color: green; }
+b[data-state="reconnecting"], b[data-state="connecting"] { color: darkorange; }
+</style>

--- a/examples/chat/vue/src/main.ts
+++ b/examples/chat/vue/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/examples/chat/vue/vite.config.ts
+++ b/examples/chat/vue/vite.config.ts
@@ -1,0 +1,6 @@
+import vue from "@vitejs/plugin-vue";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+    plugins: [vue()]
+});

--- a/examples/collab-notepad/README.md
+++ b/examples/collab-notepad/README.md
@@ -1,0 +1,32 @@
+# Collab notepad — the one-line migration
+
+A collaborative notepad written against the **standard `WebSocket` API**, made
+durable by swapping a single import:
+
+```ts
+import { WebSocket } from "durablews/compat";
+```
+
+```bash
+pnpm install && pnpm -F durablews build   # once, from the repo root
+pnpm -F example-collab-notepad dev        # server + Vite (one command)
+```
+
+Open the printed URL **twice**, side by side. Type in one window, watch the
+other. Then the durability demo: **kill the server (`Ctrl-C`), keep typing,
+restart it** — both windows walk through `reconnecting`, your buffered update
+flushes, and the documents converge. With the native `WebSocket`, the same app
+is dead at the first blip.
+
+The sync itself is deliberately demo-grade (last-write-wins full-text) — the
+point is the transport, not CRDTs.
+
+## Why not y-websocket/Yjs injection?
+
+We tried — and it taught us the layering rule now documented in the
+[compat guide](https://durablews.imns.co/guides/compat/): libraries with
+**stateful sync protocols** (y-websocket, graphql-ws) implement their *own*
+reconnection because they must re-handshake per connection. Injecting a
+self-reconnecting socket under them creates two reconnect layers fighting
+each other. Compat's sweet spot is code that treats the socket as a plain
+pipe — like this app, and like most hand-rolled WebSocket code.

--- a/examples/collab-notepad/index.html
+++ b/examples/collab-notepad/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>DurableWS — collab notepad (compat)</title>
+        <style>
+            body { font-family: system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; }
+            textarea { width: 100%; height: 320px; font: 1rem/1.5 ui-monospace, monospace; padding: 0.75rem; box-sizing: border-box; }
+            .badge { padding: 0.15rem 0.6rem; border-radius: 999px; color: white; background: #b3261e; }
+            .badge[data-state="open"] { background: #1f6e3b; }
+            .badge[data-state="connecting"], .badge[data-state="reconnecting"] { background: #8a6d00; }
+            .hint { opacity: 0.65; font-size: 0.9rem; }
+        </style>
+    </head>
+    <body>
+        <h1>Collab notepad</h1>
+        <p>
+            connection: <span id="state" class="badge">idle</span>
+            <span class="hint">— a raw-WebSocket app made durable by swapping one import</span>
+        </p>
+        <textarea id="doc" spellcheck="false"></textarea>
+        <p class="hint">
+            Open this page twice. Kill the server, keep typing, restart it.
+        </p>
+        <script type="module" src="/src/main.ts"></script>
+    </body>
+</html>

--- a/examples/collab-notepad/package.json
+++ b/examples/collab-notepad/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "example-collab-notepad",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev": "node server.mjs & vite",
+        "dev:server": "node server.mjs",
+        "build": "vite build"
+    },
+    "dependencies": {
+        "durablews": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.3",
+        "vite": "^6.3.5",
+        "ws": "^8.21.0"
+    }
+}

--- a/examples/collab-notepad/server.mjs
+++ b/examples/collab-notepad/server.mjs
@@ -1,0 +1,35 @@
+import { WebSocketServer } from "ws";
+
+// A last-write-wins shared notepad. The server owns the document: it sends
+// the current text to every new connection and re-broadcasts updates to
+// everyone else. Deliberately protocol-dumb — the client treats the socket
+// as a plain pipe, which is exactly where a drop-in durable WebSocket shines.
+const PORT = 8790;
+
+let doc =
+    "Type here. Open a second window. Then kill this server (Ctrl-C),\nkeep typing, restart it — and watch everything catch up.\n\n";
+
+const wss = new WebSocketServer({ port: PORT }, () => {
+    console.log(`collab notepad server: ws://localhost:${PORT}`);
+});
+
+wss.on("connection", (socket) => {
+    socket.send(JSON.stringify({ type: "doc", text: doc }));
+    socket.on("message", (data) => {
+        let msg;
+        try {
+            msg = JSON.parse(data.toString());
+        } catch {
+            return;
+        }
+        if (msg.type === "update" && typeof msg.text === "string") {
+            doc = msg.text;
+            const wire = JSON.stringify({ type: "doc", text: doc });
+            for (const peer of wss.clients) {
+                if (peer !== socket && peer.readyState === peer.OPEN) {
+                    peer.send(wire);
+                }
+            }
+        }
+    });
+});

--- a/examples/collab-notepad/src/main.ts
+++ b/examples/collab-notepad/src/main.ts
@@ -1,0 +1,42 @@
+// The entire migration from fragile to durable is this import. The rest of
+// this file is written against the standard WebSocket API — swap the line
+// below for the global WebSocket and the app still runs, it just dies the
+// moment the server blips.
+import { WebSocket } from "durablews/compat";
+
+const ws = new WebSocket("ws://localhost:8790");
+
+const textarea = document.getElementById("doc") as HTMLTextAreaElement;
+const badge = document.getElementById("state") as HTMLElement;
+
+ws.onmessage = (event) => {
+    const msg = JSON.parse(String(event.data)) as {
+        type: string;
+        text: string;
+    };
+    if (msg.type === "doc" && msg.text !== textarea.value) {
+        // Last-write-wins with a crude cursor save — demo-grade collaboration
+        // on purpose; the point here is the transport, not OT/CRDT.
+        const cursor = textarea.selectionStart;
+        textarea.value = msg.text;
+        textarea.setSelectionRange(cursor, cursor);
+    }
+};
+
+let throttle: ReturnType<typeof setTimeout> | undefined;
+textarea.addEventListener("input", () => {
+    clearTimeout(throttle);
+    throttle = setTimeout(() => {
+        // While the server is down this queues (bounded, observable) and
+        // flushes on recovery — the standard API gained durability semantics.
+        ws.send(JSON.stringify({ type: "update", text: textarea.value }));
+    }, 150);
+});
+
+// Everything above sticks to the WebSocket shape. This is the escape hatch:
+// the full durablews client underneath, here driving the state badge.
+ws.client.subscribe(() => {
+    const { state } = ws.client.getState();
+    badge.textContent = state;
+    badge.dataset.state = state;
+});

--- a/examples/collab-notepad/tsconfig.json
+++ b/examples/collab-notepad/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "noEmit": true,
+        "lib": ["ES2022", "DOM"]
+    },
+    "include": ["src"]
+}

--- a/examples/resilience-playground/README.md
+++ b/examples/resilience-playground/README.md
@@ -1,0 +1,24 @@
+# Resilience playground
+
+The flagship DurableWS demo: a server you can sabotage from the client, and a
+connection that survives it. Drop it, mute it, flood it while it's down —
+then watch the state machine, retry counter, and queue recover.
+
+```bash
+pnpm install && pnpm -F durablews build   # once, from the repo root
+pnpm -F example-resilience-playground dev # server + Vite (one command)
+```
+
+Open the printed Vite URL. Things to try:
+
+- **💣 Drop** — the server closes you with code 1012. The badge walks
+  `open → reconnecting → connecting → open`; the retry counter resets on
+  success.
+- **🔇 Mute** — the server stays connected but goes silent. The heartbeat
+  (2s interval here) declares the link dead, closes with code `4408`, and the
+  normal reconnect machinery gets you a fresh, unmuted connection.
+- **📬 Burst while down** — hit Drop, then immediately Burst. The messages
+  queue (watch the gauge), then flush in order the moment the socket reopens.
+- **Close, then Burst** — a deliberate close drops the queue *observably*:
+  every message surfaces in the log as a `drop` event. Nothing is silently
+  lost, ever.

--- a/examples/resilience-playground/index.html
+++ b/examples/resilience-playground/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>DurableWS — resilience playground</title>
+        <style>
+            body { font-family: ui-monospace, monospace; max-width: 760px; margin: 2rem auto; padding: 0 1rem; background: #0e1117; color: #e6edf3; }
+            h1 { font-size: 1.2rem; }
+            .row { display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; margin: 0.75rem 0; }
+            .badge { padding: 0.25rem 0.75rem; border-radius: 999px; font-weight: bold; }
+            .badge[data-state="open"] { background: #1f6e3b; }
+            .badge[data-state="connecting"], .badge[data-state="reconnecting"] { background: #8a6d00; }
+            .badge[data-state="closed"], .badge[data-state="closing"], .badge[data-state="idle"] { background: #6e1f1f; }
+            .gauge { opacity: 0.85; }
+            button { background: #21262d; color: #e6edf3; border: 1px solid #30363d; border-radius: 6px; padding: 0.4rem 0.8rem; cursor: pointer; }
+            button:hover { background: #30363d; }
+            #log { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 0.75rem; height: 320px; overflow-y: auto; font-size: 0.8rem; white-space: pre-wrap; }
+            .hint { opacity: 0.6; font-size: 0.85rem; }
+        </style>
+    </head>
+    <body>
+        <h1>DurableWS resilience playground</h1>
+        <p class="hint">
+            Your job: break the connection. Its job: survive you. Watch the
+            state machine, the retry counter, and the queue do their thing.
+        </p>
+        <div class="row">
+            <span id="state" class="badge" data-state="idle">idle</span>
+            <span class="gauge">retries: <b id="retries">0</b></span>
+            <span class="gauge">queued: <b id="queued">0</b></span>
+        </div>
+        <div class="row">
+            <button type="button" id="drop">💣 Drop the connection</button>
+            <button type="button" id="mute">🔇 Mute the server 6s (heartbeat)</button>
+            <button type="button" id="burst">📬 Send 5 while it's down</button>
+            <button type="button" id="send">Send one message</button>
+            <button type="button" id="close">Close</button>
+            <button type="button" id="connect">Connect</button>
+        </div>
+        <div id="log"></div>
+        <script type="module" src="/src/main.ts"></script>
+    </body>
+</html>

--- a/examples/resilience-playground/package.json
+++ b/examples/resilience-playground/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "example-resilience-playground",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev": "node server.mjs & vite",
+        "dev:server": "node server.mjs",
+        "build": "vite build"
+    },
+    "dependencies": {
+        "durablews": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.3",
+        "vite": "^6.3.5",
+        "ws": "^8.21.0"
+    }
+}

--- a/examples/resilience-playground/server.mjs
+++ b/examples/resilience-playground/server.mjs
@@ -1,0 +1,57 @@
+import { WebSocketServer } from "ws";
+
+// A deliberately sabotage-able WebSocket server for the resilience
+// playground. The CLIENT asks the server to misbehave:
+//   {type:"drop"}            → server closes the connection (code 1012)
+//   {type:"mute", ms}        → server goes silent on this connection for ms
+//                              (open-but-dead link: heartbeat territory)
+//   {type:"echo", body}      → echoed back
+//   "ping" (raw)             → "pong" (heartbeat reply)
+// It also ticks a timestamp every 2s per connection so traffic is visible.
+const PORT = 8788;
+
+const wss = new WebSocketServer({ port: PORT }, () => {
+    console.log(`resilience playground server: ws://localhost:${PORT}`);
+});
+
+wss.on("connection", (socket) => {
+    let mutedUntil = 0;
+    const muted = () => Date.now() < mutedUntil;
+
+    const ticker = setInterval(() => {
+        if (!muted() && socket.readyState === socket.OPEN) {
+            socket.send(JSON.stringify({ type: "tick", at: Date.now() }));
+        }
+    }, 2000);
+    socket.on("close", () => clearInterval(ticker));
+
+    socket.on("message", (data) => {
+        const text = data.toString();
+        if (text === "ping") {
+            if (!muted()) {
+                socket.send("pong");
+            }
+            return;
+        }
+        let msg;
+        try {
+            msg = JSON.parse(text);
+        } catch {
+            return;
+        }
+        if (msg.type === "drop") {
+            socket.close(1012, "you asked for it");
+            return;
+        }
+        if (msg.type === "mute") {
+            mutedUntil = Date.now() + (msg.ms ?? 6000);
+            return;
+        }
+        if (muted()) {
+            return;
+        }
+        if (msg.type === "echo") {
+            socket.send(JSON.stringify({ type: "echo", body: msg.body }));
+        }
+    });
+});

--- a/examples/resilience-playground/src/main.ts
+++ b/examples/resilience-playground/src/main.ts
@@ -1,0 +1,89 @@
+import { defineClient } from "durablews";
+
+// Everything durable is ON: default reconnection (full-jitter backoff) and
+// queueing, plus an aggressive heartbeat so the "mute" sabotage is detected
+// in seconds rather than relying on TCP timeouts.
+const ws = defineClient({
+    url: "ws://localhost:8788",
+    heartbeat: { interval: 2000, timeout: 2500 }
+});
+
+const el = (id: string) => {
+    const node = document.getElementById(id);
+    if (!node) {
+        throw new Error(`missing #${id}`);
+    }
+    return node;
+};
+const log = (line: string, kind = "info") => {
+    const pane = el("log");
+    const at = new Date().toLocaleTimeString();
+    pane.append(`${at}  ${kind === "bad" ? "✗" : "•"} ${line}\n`);
+    pane.scrollTop = pane.scrollHeight;
+};
+
+// The reactive seam: one subscription drives every gauge.
+function render() {
+    const { state, retryAttempt, queueLength } = ws.getState();
+    const badge = el("state");
+    badge.textContent = state;
+    badge.dataset.state = state;
+    el("retries").textContent = String(retryAttempt);
+    el("queued").textContent = String(queueLength);
+}
+ws.subscribe(render);
+render();
+
+ws.on("open", () => log("open — connected"));
+ws.on("close", (event) => log(`close (code ${event.code})`, "bad"));
+ws.on("reconnecting", ({ attempt, delay }) =>
+    log(`reconnecting: attempt ${attempt} in ${Math.round(delay)}ms`)
+);
+ws.on("error", (err) =>
+    log(
+        `error: ${err instanceof Error ? err.message : "transport error"}`,
+        "bad"
+    )
+);
+ws.on("drop", ({ data, reason }) =>
+    log(`DROPPED (${reason}): ${JSON.stringify(data)}`, "bad")
+);
+ws.on("message", (msg) => {
+    const m = msg as { type?: string; body?: unknown; at?: number };
+    if (m?.type === "tick") {
+        log("tick from server");
+        return;
+    }
+    if (m?.type === "echo") {
+        log(`echo: ${JSON.stringify(m.body)}`);
+        return;
+    }
+    log(`message: ${JSON.stringify(msg)}`);
+});
+
+let n = 0;
+el("drop").onclick = () => {
+    log("asking the server to drop us…");
+    ws.send({ type: "drop" });
+};
+el("mute").onclick = () => {
+    log("muting the server 6s — watch the heartbeat declare it dead (4408)");
+    ws.send({ type: "mute", ms: 6000 });
+};
+el("send").onclick = () => {
+    ws.send({ type: "echo", body: `hello #${++n}` });
+};
+el("burst").onclick = () => {
+    log("sending 5 — if we're down, watch them queue, then flush on open");
+    for (let i = 0; i < 5; i++) {
+        ws.send({ type: "echo", body: `burst ${++n}` });
+    }
+};
+el("close").onclick = () => {
+    ws.close();
+};
+el("connect").onclick = () => {
+    ws.connect().catch(() => {});
+};
+
+ws.connect().catch(() => {});

--- a/examples/resilience-playground/tsconfig.json
+++ b/examples/resilience-playground/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "noEmit": true,
+        "lib": ["ES2022", "DOM"]
+    },
+    "include": ["src"]
+}

--- a/packages/durablews/e2e/echo-standalone.mjs
+++ b/packages/durablews/e2e/echo-standalone.mjs
@@ -1,0 +1,31 @@
+import { WebSocketServer } from "ws";
+
+// Runs the e2e echo server as a long-lived process for the cross-runtime
+// smoke tests: Deno/Bun can't host the Node `ws` server themselves, so it
+// runs under Node and they connect to it. Same protocol as echo-server.mjs
+// ("ping" → "pong", "drop" → close 1012, "mute" → silence; otherwise echo).
+// WS_PORT pins the port (default 8787); prints `PORT=<n>` when listening.
+const port = process.env.WS_PORT ? Number(process.env.WS_PORT) : 8787;
+
+const wss = new WebSocketServer({ port }, () => {
+    console.log(`PORT=${port}`);
+});
+
+wss.on("connection", (socket) => {
+    let muted = false;
+    socket.on("message", (data) => {
+        const text = data.toString();
+        if (text === "mute") {
+            muted = true;
+            return;
+        }
+        if (muted) {
+            return;
+        }
+        if (text === "drop") {
+            socket.close(1012, "server drop");
+            return;
+        }
+        socket.send(text === "ping" ? "pong" : text);
+    });
+});

--- a/packages/durablews/e2e/runtime-smoke.mjs
+++ b/packages/durablews/e2e/runtime-smoke.mjs
@@ -1,0 +1,107 @@
+// Cross-runtime smoke test: the same script runs unchanged under Node ≥22,
+// Deno, and Bun against the built ESM bundle and a real echo server
+// (e2e/echo-standalone.mjs, running under Node). It proves the §6 claim —
+// "multi-runtime via the standard global WebSocket" — per runtime:
+//   1. lifecycle walk (idle → connecting → open) and an echo round trip
+//   2. transparent reconnection after a server-initiated drop
+//   3. queueing while disconnected, flushed after recovery
+//
+// Usage: WS_PORT=8787 {node|deno run --allow-net --allow-read|bun} runtime-smoke.mjs
+// Exits 0 on success, 1 on any failure or after a 20s watchdog.
+
+import { defineClient } from "../dist/index.js";
+
+const port = Number(
+    (globalThis.Deno
+        ? globalThis.Deno.env.get("WS_PORT")
+        : process.env.WS_PORT) ?? 8787
+);
+const url = `ws://127.0.0.1:${port}`;
+
+const watchdog = setTimeout(() => {
+    console.error("FAIL: smoke test timed out after 20s");
+    exit(1);
+}, 20_000);
+
+function exit(code) {
+    clearTimeout(watchdog);
+    if (globalThis.Deno) {
+        globalThis.Deno.exit(code);
+    } else {
+        process.exit(code);
+    }
+}
+
+function assert(condition, label) {
+    if (!condition) {
+        console.error(`FAIL: ${label}`);
+        exit(1);
+    }
+    console.log(`ok: ${label}`);
+}
+
+function nextMessage(client) {
+    return new Promise((resolve) => {
+        const off = client.on("message", (msg) => {
+            off();
+            resolve(msg);
+        });
+    });
+}
+
+const client = defineClient({
+    url,
+    reconnect: { baseDelay: 50, jitter: false }
+});
+
+// 1. Lifecycle + echo round trip.
+assert(client.state === "idle", "starts idle");
+const opened = client.connect();
+assert(client.state === "connecting", "connecting after connect()");
+await opened;
+assert(client.state === "open", "open after connect() resolves");
+
+const echoed = nextMessage(client);
+client.send({ runtime: "smoke", n: 1 });
+const reply = await echoed;
+assert(
+    reply !== null &&
+        typeof reply === "object" &&
+        reply.runtime === "smoke" &&
+        reply.n === 1,
+    "JSON echo round trip"
+);
+
+// 2. Server drop → transparent reconnection.
+const reconnecting = new Promise((resolve) => {
+    const off = client.on("reconnecting", (info) => {
+        off();
+        resolve(info);
+    });
+});
+const reopened = new Promise((resolve) => {
+    const off = client.on("open", () => {
+        off();
+        resolve(null);
+    });
+});
+client.send("drop");
+const retry = await reconnecting;
+assert(retry.attempt === 1, "reconnecting event after server drop");
+
+// 3. Queue while disconnected (the socket is gone, the retry is pending).
+client.send({ queued: true });
+assert(client.getState().queueLength === 1, "send() queued while reconnecting");
+
+await reopened;
+assert(client.state === "open", "transparently reconnected");
+const flushed = await nextMessage(client);
+assert(
+    flushed !== null && typeof flushed === "object" && flushed.queued === true,
+    "queued message flushed after recovery"
+);
+assert(client.getState().queueLength === 0, "queue drained");
+
+client.close();
+console.log("smoke: all checks passed");
+exit(0);

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -63,7 +63,8 @@
         "typecheck": "tsc --noEmit",
         "typecheck:next": "pnpm --package=typescript@next dlx tsc --noEmit",
         "check:publish": "publint && attw --pack . --profile node16",
-        "prepublishOnly": "pnpm build"
+        "prepublishOnly": "pnpm build",
+        "size": "size-limit"
     },
     "author": "Nate Smith (https://imns.co/)",
     "license": "MPL-2.0",
@@ -115,6 +116,7 @@
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.3",
         "@playwright/test": "^1.60.0",
+        "@size-limit/preset-small-lib": "^12.1.0",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^22.19.20",
         "@types/react": "^19.2.17",
@@ -124,11 +126,44 @@
         "publint": "^0.3.21",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "size-limit": "^12.1.0",
         "tsup": "^8.5.1",
         "typescript": "^5.3.3",
         "vitest": "^1.2.2",
         "vitest-websocket-mock": "^0.3.0",
         "vue": "^3.5.35",
         "ws": "^8.21.0"
-    }
+    },
+    "size-limit": [
+        {
+            "name": "core (durablews)",
+            "path": "dist/index.js",
+            "limit": "3 KB",
+            "brotli": true
+        },
+        {
+            "name": "durablews/vue",
+            "path": "dist/vue.js",
+            "limit": "3.5 KB",
+            "brotli": true,
+            "ignore": [
+                "vue"
+            ]
+        },
+        {
+            "name": "durablews/react",
+            "path": "dist/react.js",
+            "limit": "3.5 KB",
+            "brotli": true,
+            "ignore": [
+                "react"
+            ]
+        },
+        {
+            "name": "durablews/compat",
+            "path": "dist/compat.js",
+            "limit": "4 KB",
+            "brotli": true
+        }
+    ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,78 @@ importers:
         specifier: ^4.98.0
         version: 4.98.0(@cloudflare/workers-types@4.20260607.1)
 
+  examples/chat:
+    dependencies:
+      durablews:
+        specifier: workspace:*
+        version: link:../../packages/durablews
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      vue:
+        specifier: ^3.5.35
+        version: 3.5.35(typescript@5.9.3)
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.3(@types/node@24.13.1))
+      '@vitejs/plugin-vue':
+        specifier: ^5.2.4
+        version: 5.2.4(vite@6.4.3(@types/node@24.13.1))(vue@3.5.35(typescript@5.9.3))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.3(@types/node@24.13.1)
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
+
+  examples/collab-notepad:
+    dependencies:
+      durablews:
+        specifier: workspace:*
+        version: link:../../packages/durablews
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.3(@types/node@24.13.1)
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
+
+  examples/resilience-playground:
+    dependencies:
+      durablews:
+        specifier: workspace:*
+        version: link:../../packages/durablews
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.3(@types/node@24.13.1)
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
+
   packages/durablews:
     devDependencies:
       '@arethetypeswrong/cli':
@@ -45,6 +117,9 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      '@size-limit/preset-small-lib':
+        specifier: ^12.1.0
+        version: 12.1.0(size-limit@12.1.0)
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -72,6 +147,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      size-limit:
+        specifier: ^12.1.0
+        version: 12.1.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)
@@ -151,6 +229,40 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -159,13 +271,41 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -453,6 +593,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -479,6 +625,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -513,6 +665,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -539,6 +697,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -573,6 +737,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -599,6 +769,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -633,6 +809,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -659,6 +841,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -693,6 +881,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -719,6 +913,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -753,6 +953,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -779,6 +985,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -813,6 +1025,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -839,6 +1057,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -873,6 +1097,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -899,6 +1129,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -933,6 +1169,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -953,6 +1195,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -987,6 +1235,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -1007,6 +1261,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1041,6 +1301,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
@@ -1061,6 +1327,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1095,6 +1367,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -1121,6 +1399,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1155,6 +1439,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -1181,6 +1471,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1366,6 +1662,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1461,6 +1760,9 @@ packages:
   '@publint/pack@0.1.4':
     resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
     engines: {node: '>=18'}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/pluginutils@5.4.0':
     resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
@@ -1641,6 +1943,23 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
+  '@size-limit/esbuild@12.1.0':
+    resolution: {integrity: sha512-Um6MVrX+05kIxI4+zk0ZByG9dA/Th1f+sfGc571D95BnCPc90/pl2+2OdsQuOyoWEbeAMqfcTKo0v07i+E65Vw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
+  '@size-limit/preset-small-lib@12.1.0':
+    resolution: {integrity: sha512-TVVQ/iuHbaGtHJrjur5s4XKYEyGk0nIwUAqhuzhKPbTyV9nYOH/laDelQ4vg3cGmm8sayRx998wxEdnwM/Yewg==}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
@@ -1665,6 +1984,18 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -1727,6 +2058,19 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
 
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
@@ -1881,6 +2225,11 @@ packages:
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
+  baseline-browser-mapping@2.10.34:
+    resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
@@ -1905,11 +2254,20 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1922,6 +2280,9 @@ packages:
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
+
+  caniuse-lite@1.0.30001797:
+    resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2033,6 +2394,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -2180,6 +2544,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  electron-to-chromium@1.5.369:
+    resolution: {integrity: sha512-XM22K9FNaaCOvMMrBn1caIc8v0g6+pKt660ZbfQqUZvfil0hEzr8ZoiY7VcSLGM3L/x3rz5PqZrk+bKOOmVM9w==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -2259,6 +2626,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2380,6 +2752,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -2659,6 +3035,16 @@ packages:
       canvas:
         optional: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
@@ -2762,6 +3148,9 @@ packages:
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -3022,6 +3411,14 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
@@ -3038,6 +3435,10 @@ packages:
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3294,6 +3695,10 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
@@ -3435,6 +3840,10 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.8.2:
     resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
     engines: {node: '>=10'}
@@ -3469,6 +3878,16 @@ packages:
     resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
+
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -3816,6 +4235,12 @@ packages:
       uploadthing:
         optional: true
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
@@ -4087,6 +4512,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -4306,15 +4734,108 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.7':
     dependencies:
@@ -4602,6 +5123,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
@@ -4615,6 +5139,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -4632,6 +5159,9 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
     optional: true
 
@@ -4645,6 +5175,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -4662,6 +5195,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
@@ -4675,6 +5211,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -4692,6 +5231,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
@@ -4705,6 +5247,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -4722,6 +5267,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
@@ -4735,6 +5283,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -4752,6 +5303,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
@@ -4765,6 +5319,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -4782,6 +5339,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
@@ -4795,6 +5355,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -4812,6 +5375,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
@@ -4825,6 +5391,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -4842,6 +5411,9 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
@@ -4852,6 +5424,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -4869,6 +5444,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
@@ -4879,6 +5457,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -4896,6 +5477,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
@@ -4906,6 +5490,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -4923,6 +5510,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
@@ -4936,6 +5526,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -4953,6 +5546,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
@@ -4966,6 +5562,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@expressive-code/core@0.41.7':
@@ -5105,6 +5704,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -5223,6 +5827,8 @@ snapshots:
   '@poppinss/exception@1.2.3': {}
 
   '@publint/pack@0.1.4': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/pluginutils@5.4.0(rollup@4.61.1)':
     dependencies:
@@ -5346,6 +5952,22 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
+  '@size-limit/esbuild@12.1.0(size-limit@12.1.0)':
+    dependencies:
+      esbuild: 0.28.0
+      nanoid: 5.1.11
+      size-limit: 12.1.0
+
+  '@size-limit/file@12.1.0(size-limit@12.1.0)':
+    dependencies:
+      size-limit: 12.1.0
+
+  '@size-limit/preset-small-lib@12.1.0(size-limit@12.1.0)':
+    dependencies:
+      '@size-limit/esbuild': 12.1.0(size-limit@12.1.0)
+      '@size-limit/file': 12.1.0(size-limit@12.1.0)
+      size-limit: 12.1.0
+
   '@speed-highlight/core@1.2.15': {}
 
   '@testing-library/dom@10.4.1':
@@ -5370,6 +5992,27 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@types/debug@4.1.13':
     dependencies:
@@ -5434,6 +6077,23 @@ snapshots:
       '@types/node': 20.19.42
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@24.13.1))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@24.13.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.3(@types/node@24.13.1))(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      vite: 6.4.3(@types/node@24.13.1)
+      vue: 3.5.35(typescript@5.9.3)
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -5696,6 +6356,8 @@ snapshots:
 
   base-64@1.0.0: {}
 
+  baseline-browser-mapping@2.10.34: {}
+
   bcp-47-match@2.0.3: {}
 
   bcp-47@2.1.0:
@@ -5727,10 +6389,20 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.34
+      caniuse-lite: 1.0.30001797
+      electron-to-chromium: 1.5.369
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
+
+  bytes-iec@3.1.1: {}
 
   cac@6.7.14: {}
 
@@ -5740,6 +6412,8 @@ snapshots:
       function-bind: 1.1.2
 
   camelcase@8.0.0: {}
+
+  caniuse-lite@1.0.30001797: {}
 
   ccount@2.0.1: {}
 
@@ -5838,6 +6512,8 @@ snapshots:
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
@@ -5968,6 +6644,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  electron-to-chromium@1.5.369: {}
 
   emoji-regex@10.6.0: {}
 
@@ -6163,6 +6841,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -6299,6 +7006,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -6707,6 +7416,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -6786,6 +7499,10 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   lz-string@1.5.0: {}
 
@@ -7344,6 +8061,12 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  nanoid@5.1.11: {}
+
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   neotraverse@0.6.18: {}
 
   nlcst-to-string@4.0.0:
@@ -7360,6 +8083,8 @@ snapshots:
   node-fetch-native@1.6.7: {}
 
   node-mock-http@1.0.4: {}
+
+  node-releases@2.0.47: {}
 
   normalize-path@3.0.0: {}
 
@@ -7591,6 +8316,8 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-refresh@0.17.0: {}
 
   react@19.2.7: {}
 
@@ -7829,6 +8556,8 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  semver@6.3.1: {}
+
   semver@7.8.2: {}
 
   sharp@0.34.5:
@@ -7891,6 +8620,14 @@ snapshots:
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.6.0
+
+  size-limit@12.1.0:
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.17
 
   skin-tone@2.0.0:
     dependencies:
@@ -8183,6 +8920,12 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   url-parse@1.5.10:
     dependencies:
       querystringify: 2.2.0
@@ -8410,6 +9153,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yargs-parser@20.2.9: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/*"
   - "docs"
+  - "examples/*"
 allowBuilds:
   esbuild: true
   lefthook: true

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -641,9 +641,25 @@ stops moving; release is last.
   option in support: `binaryType`, applied to the socket on every
   (re)connect — generally useful for binary protocols, not compat-specific.
   E2e: the compat class survives a server drop in real Chromium.
-- ⬜ **Slice 6 — Cross-runtime e2e + distribution assets.** Node-as-client +
-  Deno/Bun e2e (closing §6's claim); size-limit budget enforced in CI + badge;
-  runnable `examples/`.
+- ✅ **Slice 6 — Cross-runtime e2e + distribution assets.** One smoke script
+  (`e2e/runtime-smoke.mjs` — lifecycle walk, JSON echo, transparent
+  reconnect after a server drop, queue-flush-after-recovery) runs unchanged
+  under **Node 22, Deno 2, and Bun** against the built bundle + a real echo
+  server, as three required CI jobs — §6's multi-runtime claim is now
+  proven, not stated (browser was already covered by Playwright).
+  **size-limit** budgets enforced in CI (brotli, minified, all deps): core
+  **3 KB** (measures 2.36), vue/react 3.5 KB, compat 4 KB; README badges
+  (npm@alpha, CI, size). Runnable **`examples/`** (workspace members, built
+  in CI): `resilience-playground` (sabotage-the-server flagship),
+  `chat` (Vue + React against one server + one zod schema),
+  `collab-notepad` (raw-WebSocket app made durable via the compat one-line
+  swap). *Example-3 rescope, decided during implementation:* the planned
+  y-websocket/Yjs injection demo was dropped — y-websocket runs its own
+  reconnection (stateful sync protocols must), so injecting a
+  self-reconnecting socket creates two fighting recovery layers; the
+  **layering rule is now documented in the compat guide** ("one reconnector
+  per stack", with a `reconnect: false` wrapper recipe), and the example
+  demonstrates compat where it genuinely owns durability: plain-pipe code.
 - ⬜ **Slice 7 — 2.0 release.** Changesets-automated npm publish of
   `durablews@2.0.0`; launch post ("we fixed reconnection properly: full
   jitter, bounded queues, an FSM").


### PR DESCRIPTION
## Summary

M4 slice 6 — the distribution-assets slice. Three deliverables:

**Cross-runtime proof.** One smoke script (`e2e/runtime-smoke.mjs`) runs unchanged under **Node 22, Deno 2, and Bun** against the built bundle and a real echo server: lifecycle walk, JSON echo, transparent reconnect after a server-initiated drop, queue-flush after recovery. Three new CI jobs (`E2E (Node)`, `E2E (Deno)`, `E2E (Bun)`); Node and Bun verified locally (9/9 checks each). With the existing Playwright job, §6's multi-runtime claim is now **tested in four runtimes, not stated**.

**Size budgets, CI-enforced.** size-limit (brotli, minified, with all deps): core **3 KB** (measures 2.36 KB), vue/react 3.5 KB, compat 4 KB. New `Size` CI job; README gains npm@alpha / CI / size badges.

**Runnable examples** (workspace members; a new `Examples` CI job builds all three):
- `resilience-playground` — the flagship: sabotage the server from the UI (drop, mute-for-heartbeat, burst-while-down) and watch the FSM badge, retry counter, and queue gauges survive, all driven by one `subscribe()`.
- `chat` — Vue composable and React hook against **one server and one shared zod schema**; presence, typing indicators via the call-site-throttle pattern.
- `collab-notepad` — a collaborative editor written against the standard `WebSocket` API, made durable by swapping one import (`durablews/compat`), with the `.client` escape hatch driving the state badge.

## Example-3 rescope (decided during implementation, recorded in the RFC)

The plan said y-websocket/Yjs injection. Building it surfaced a real problem: **y-websocket runs its own reconnection** (stateful sync protocols must — they re-handshake per connection), so injecting a self-reconnecting socket creates two recovery layers fighting each other (the provider abandons the socket on `close` while the socket revives itself — zombies). And since y-websocket already survives restarts natively, the demo would have shown nothing we add. The example now demonstrates compat where it genuinely owns durability (plain-pipe code), and the **layering rule is documented in the compat guide** — "one reconnector per stack", with a `reconnect: false` wrapper recipe for stateful-protocol libraries.

Also: Biome overrides for `.vue` files (it can't see `<template>` usage of script-setup bindings, and `useHookAtTopLevel` is a React rule misfiring on composables).

After merge: the five new jobs get added to the branch ruleset's required checks (CI↔ruleset lockstep).