### PR TITLE
chore(release): push the Version PR with RELEASE_TOKEN (checks run automatically)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,16 +56,10 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # KNOWN LIMITATION — the Version PR opens without its required checks:
-      # the changesets action pushes with GITHUB_TOKEN, whose events never
-      # trigger workflows (GitHub's recursion guard). A workflow_dispatch'd
-      # CI run was tried and rejected: its check suite lands on the commit
-      # but GitHub does not associate workflow_dispatch suites with PRs, so
-      # the merge gate ignores it. The two real options:
-      #   1. (recommended) a fine-grained PAT (contents + pull-requests:
-      #      write, this repo only) as a RELEASE_TOKEN secret, passed to the
-      #      changesets step's GITHUB_TOKEN env — its pushes trigger CI
-      #      normally;
-      #   2. one manual nudge per release: close + reopen the Version PR
-      #      (any real user's event re-triggers CI).
+          # RELEASE_TOKEN: a fine-grained PAT (this repo only; contents +
+          # pull-requests write — deliberately NO workflows permission).
+          # The built-in GITHUB_TOKEN cannot be used here: its pushes never
+          # trigger workflows (GitHub's recursion guard), so the Version PR
+          # would open without its required checks. A real credential's
+          # pushes fire CI normally and the PR arrives mergeable.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

The final piece of release automation. The changesets step now authenticates with the `RELEASE_TOKEN` fine-grained PAT (scoped to this repo; contents + pull-requests write; deliberately **no** workflows permission, so the token cannot modify CI). Its pushes to `changeset-release/main` are real-user events, so the Version PR's required checks fire on their own — no more close/reopen nudges.

**Live verification on merge:** the release run this merge triggers will rebuild Version PR #40 using the token; #40 should turn green unassisted. If the run fails with an auth error, the secret name doesn't match `RELEASE_TOKEN` — a rename fixes it.