### PR TITLE
fix(release): give checkout the RELEASE_TOKEN — git pushes use its credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The changesets action pushes through git, which uses the
+          # credentials checkout persists — not the action's env token. The
+          # PAT must live here for the Version PR branch push to be a
+          # real-user event (which is what makes its CI checks run).
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: Install pnpm
         uses: pnpm/action-setup@v4
       - name: Setup Node


### PR DESCRIPTION
PR #43 put the PAT only in the changesets step's env, but the action pushes the Version PR branch through git, which uses the credentials `actions/checkout` persisted — the built-in `GITHUB_TOKEN`. So the push was still a bot event and #40's checks never started.

This moves the PAT to where the push actually happens: `checkout.with.token`. After this lands, the release run rebuilds the Version PR head as a real-user push and its CI checks should start unassisted.

This is the live verdict on keeping the changesets action: if #40 goes green on its own after this, we keep it; if not, we rip out the bot-PR half.