### PR TITLE
docs(rfc): mark M4 complete — durablews@2.0.0 is live

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Dispatched by the release workflow against changeset-release/main: pushes
-  # made with GITHUB_TOKEN never trigger pull_request workflows (GitHub's
-  # recursion guard), but workflow_dispatch is exempt — so the Version
-  # Packages PR gets its required checks this way.
+  # Manual runs from the Actions UI. (The Version Packages PR no longer needs
+  # this: release.yml pushes its branch with RELEASE_TOKEN, so checks fire
+  # natively.)
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # DurableWS
 
-[![npm](https://img.shields.io/npm/v/durablews/alpha?label=npm%40alpha)](https://www.npmjs.com/package/durablews)
+[![npm](https://img.shields.io/npm/v/durablews)](https://www.npmjs.com/package/durablews)
 [![CI](https://github.com/imnsco/DurableWS/actions/workflows/ci.yml/badge.svg)](https://github.com/imnsco/DurableWS/actions/workflows/ci.yml)
 [![bundle size](https://img.shields.io/badge/core-%E2%89%A4%203%20KB%20brotli%20(CI--enforced)-blue)](packages/durablews/package.json)
 [![license](https://img.shields.io/badge/license-MPL--2.0-green)](LICENSE)
 
 > The WebSocket client that survives the real world — automatic reconnection, bounded queueing, and typed messages. Zero dependencies, built on the standard `WebSocket`, the same in every modern runtime (browser, Node ≥22, Deno, Bun, edge).
 
-> ⚠️ **v2 is in alpha** (`npm install durablews@alpha`). See [RFC 0001](rfcs/0001-v2-architecture.md) for the architecture and a live status tracker, and **[durablews.imns.co](https://durablews.imns.co)** for the docs.
+> **v2.0 is out** — `npm install durablews`. See **[durablews.imns.co](https://durablews.imns.co)** for the docs, and [RFC 0001](rfcs/0001-v2-architecture.md) for the architecture and a live status tracker.
 
 The published library lives in **[`packages/durablews`](packages/durablews)** — see its [README](packages/durablews/README.md) for usage, the feature status, and requirements.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,13 @@
 
 ## Supported versions
 
-DurableWS v2 is in active development (`2.0.0-alpha`). Until v2 is released,
-security fixes are applied to `main` only. The legacy `1.x` line is not
-maintained.
+Security fixes are applied to the current `2.x` line (released from `main`).
+The legacy `1.x` line is not maintained.
 
-| Version      | Supported           |
-| ------------ | ------------------- |
-| `2.x` (main) | ✅ (in development) |
-| `1.x`        | ❌                  |
+| Version | Supported |
+| ------- | --------- |
+| `2.x`   | ✅        |
+| `1.x`   | ❌        |
 
 ## Reporting a vulnerability
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -7,8 +7,8 @@
 > (auth-ready), a pluggable codec, and Vue/React bindings in the box. Built on
 > the standard global WebSocket: browsers, Node >= 22, Deno, Bun, edge.
 
-Install: `npm install durablews@alpha` (v2 is in alpha; the 1.x release on npm
-predates the rewrite and should not be used).
+Install: `npm install durablews` (the 1.x release on npm predates the v2
+rewrite and should not be used).
 
 Quick start:
 

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -42,7 +42,7 @@ including the places the alternatives are ahead today.
 | Drop-in `WebSocket` class | ✅ [`durablews/compat`](/guides/compat/) | ✅ | ✅ |
 | Dynamic URL provider | ❌ (on the radar) | ✅ sync/async | ❌ |
 | Zero dependencies | ✅ | ✅ | ✅ |
-| Actively maintained | ✅ (alpha) | ✅ | last release 2020 |
+| Actively maintained | ✅ | ✅ | last release 2020 |
 
 ## What the differences mean in practice
 
@@ -75,6 +75,6 @@ Honesty over marketing:
   DurableWS handles token freshness via outbound middleware, but per-connect
   URL re-resolution isn't built yet.
 - **Years in production.** The reconnecting-websocket lineage has carried an
-  enormous amount of traffic. DurableWS 2.0 is an alpha with a thorough test
+  enormous amount of traffic. DurableWS 2.0 is new, with a thorough test
   pyramid (unit, integration, real-browser e2e) — but production-miles are
   earned, not claimed.

--- a/docs/src/content/docs/frameworks/react.md
+++ b/docs/src/content/docs/frameworks/react.md
@@ -9,7 +9,7 @@ No extra package — React is an *optional* peer dependency, so installing
 import it. React 18+ is required.
 
 ```bash
-npm install durablews@alpha
+npm install durablews
 ```
 
 ## Quick start

--- a/docs/src/content/docs/frameworks/vue.md
+++ b/docs/src/content/docs/frameworks/vue.md
@@ -9,7 +9,7 @@ No extra package — Vue is an *optional* peer dependency, so installing
 import it.
 
 ```bash
-npm install durablews@alpha
+npm install durablews
 ```
 
 ## Quick start

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -3,13 +3,6 @@ title: Getting started
 description: Install DurableWS and open your first connection.
 ---
 
-:::caution[Alpha]
-v2 (`2.0.0-alpha`) is in active development. The current npm release (`1.x`)
-predates this redesign, and the durability features below are still being
-built — track progress in the
-[architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md).
-:::
-
 ## Requirements
 
 DurableWS targets the standard global `WebSocket` with **zero runtime
@@ -23,7 +16,7 @@ dependencies**:
 ## Installation
 
 ```bash
-npm install durablews@alpha
+npm install durablews
 ```
 
 ## Quick start

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -20,13 +20,6 @@ hero:
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-:::note[Alpha]
-v2 is published as `durablews@alpha`. The features below are built and tested
-(unit, integration, real-browser e2e); the API may still shift before 2.0 —
-the [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
-tracks design and status.
-:::
-
 <CardGrid stagger>
 	<Card title="Durable by default" icon="random">
 		Automatic reconnection with full-jitter backoff and bounded message

--- a/packages/durablews/README.md
+++ b/packages/durablews/README.md
@@ -4,11 +4,10 @@
 > bounded queueing, and typed messages. Zero dependencies, every modern
 > runtime, durable by default.
 
-> ⚠️ **v2 is in alpha** (`npm install durablews@alpha`). The features below
-> are built and tested (unit, integration, real-browser e2e); the API may
-> still shift before 2.0. The
+> The features below are built and tested (unit, integration, real-browser
+> e2e). The
 > [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
-> tracks design and status. The `1.x` release predates this rewrite — don't
+> tracks design and status. The `1.x` line predates the v2 rewrite — don't
 > use it.
 
 ## What you get
@@ -43,7 +42,7 @@
 ## Installation
 
 ```bash
-npm install durablews@alpha
+npm install durablews
 ```
 
 ## Quick start

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -535,7 +535,7 @@ separate test/e2e slice.
   ("mute") → real Chromium detects the dead link via heartbeat and recovers on
   a fresh connection.
 
-### M4 — Adoption: docs, bindings, typed DX & 2.0 release 🚧
+### M4 — Adoption: docs, bindings, typed DX & 2.0 release ✅
 
 Renamed from "docs content & add-ons" — M4 is the **adoption milestone**. The
 premise (§2.1): libraries don't become popular at 1.0; they become popular when
@@ -660,17 +660,18 @@ stops moving; release is last.
   **layering rule is now documented in the compat guide** ("one reconnector
   per stack", with a `reconnect: false` wrapper recipe), and the example
   demonstrates compat where it genuinely owns durability: plain-pipe code.
-- 🚧 **Slice 7 — 2.0 release.** Prepared, one merge from done: pre mode
-  exited, the 2.0.0 graduation changeset written (version math verified:
-  `2.0.0`), private workspace packages excluded from changesets versioning,
-  and the launch post drafted (moved to the maintainer's blog repo,
-  `imns-co-astro`, as a `draft: true` post — publish it alongside the
-  release).
-  **Merging the auto-opened Version Packages PR publishes
-  `durablews@2.0.0` to `latest`** via OIDC trusted publishing — that merge
-  is the deliberate human step, left to the maintainer (alpha.1 shipped
-  the same night; whether to let it bake first is a judgment call the
-  maintainer should make awake).
+- ✅ **Slice 7 — 2.0 release.** **`durablews@2.0.0` is live on npm `latest`**
+  (published 2026-06-10 via OIDC trusted publishing, with provenance
+  attestations) — the maintainer merged the Version Packages PR (#40) as the
+  deliberate human step. Release-pipeline hardening landed along the way:
+  the Version PR's required checks never started because pushes made with
+  the built-in `GITHUB_TOKEN` don't trigger workflows (GitHub's recursion
+  guard); fixed by giving the `RELEASE_TOKEN` fine-grained PAT to **both**
+  the changesets step's env (#43) *and* `actions/checkout`'s `token` (#44 —
+  the action pushes through git, which uses checkout's persisted
+  credentials). Version PRs now arrive with live checks, unassisted.
+  Remaining launch chore (outside the repo): flip the launch post to
+  `draft: false` in `imns-co-astro`.
 
 ## 9. Open questions
 


### PR DESCRIPTION
Closes out M4 in the RFC tracker:

- M4 header and slice 7 → ✅. Records the release-pipeline fix that made the Version PR's checks run unassisted (RELEASE_TOKEN in both the changesets env, #43, and the checkout token, #44).
- Removes a stale comment in ci.yml that still described the reverted workflow_dispatch check-association approach (#37/#41) as active; workflow_dispatch itself stays for manual UI runs.

`durablews@2.0.0` is live on npm `latest` (OIDC, with provenance).