### PR TITLE
chore: README-only 2.0.1 patch — refresh the npm page

### DIFF
--- a/.changeset/readme-de-alpha.md
+++ b/.changeset/readme-de-alpha.md
@@ -1,0 +1,5 @@
+---
+"durablews": patch
+---
+
+README: drop the alpha banner and `@alpha` install instructions — 2.0.0 is the latest release. No code changes; this publish exists so the npm page stops showing alpha framing.


### PR DESCRIPTION
npm renders the README from the published tarball, and 2.0.0 was packed before #45's alpha cleanup — so npmjs.com/package/durablews still shows the alpha banner and `@alpha` install command.

A README can't be updated on npm without a publish, so this adds a patch changeset. Merging this opens the 2.0.1 Version PR; merging that publishes the corrected README. No code changes.