### PR TITLE
docs: formalize the planning process — RFC lifecycle, roadmap, docs changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing! DurableWS is being built in the open, and contributions — issues, docs, fixes, features — are welcome.
 
-> **Heads up:** v2 is under active redesign. Before starting non-trivial work, please read [RFC 0001](rfcs/0001-v2-architecture.md) (the architecture and live status) and open an issue to discuss, so effort isn't spent on something the redesign changes.
+> **Where things stand:** v2 has shipped (`durablews@2.0.0`). [ROADMAP.md](ROADMAP.md) is the live plan; [RFC 0001](rfcs/0001-v2-architecture.md) records the architecture and why it is the way it is. Before starting non-trivial work, see [Proposing changes](#proposing-changes).
 
 ## Prerequisites
 
@@ -48,6 +48,14 @@ pnpm changeset
 ```
 
 Pick the appropriate semver bump and write a short, user-facing summary. Tooling-only or docs-only changes that don't affect consumers don't need one.
+
+## Proposing changes
+
+Match the weight of the process to the weight of the change:
+
+- **Bug fixes and small improvements** — open a PR directly.
+- **Features** — open an issue first, so the approach is agreed before code is written. Scheduled work lives in [ROADMAP.md](ROADMAP.md).
+- **Architecture-level changes** — public API shape, packaging/exports, protocol semantics; anything expensive to reverse — start an RFC. The process is one page: [rfcs/README.md](rfcs/README.md).
 
 ## Pull requests
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,51 @@
+# Roadmap
+
+The live plan for DurableWS, updated as work lands. Ordering within a
+section is by leverage, not commitment. Scheduled items become GitHub
+issues when work starts; architecture-level items get an RFC first (see
+[rfcs/README.md](rfcs/README.md)). The v2 design itself — milestones
+M1–M4, shipped as `durablews@2.0.0` — is recorded in
+[RFC 0001](rfcs/0001-v2-architecture.md); milestone numbering continues
+from there.
+
+## Now — M5: adoption follow-through
+
+- **Dynamic URL provider.** Accept `url` as a sync or async function,
+  re-resolved on every (re)connect attempt — the token-in-URL auth
+  pattern. Closes the first concession in the docs'
+  [comparison page](https://durablews.imns.co/comparison/).
+- **Built-in middleware pack.** A `durablews/middleware` subpath: named
+  exports, side-effect-free, tree-shakable — middleware you don't import
+  costs zero bundle bytes, enforced with a dedicated size-limit budget in
+  CI. Candidate set still to be settled (logger/devtools, token-refresh —
+  the canonical async outbound case — inbound dedup). Per-key
+  debounce/batch deliberately stay send-wrappers, not middleware
+  (RFC 0001 §9 records why).
+- **Examples in the docs.** One page per runnable example (its thesis,
+  the load-bearing code excerpt, run instructions, GitHub link) plus an
+  Examples card on the docs homepage. Follow-up: "Open in StackBlitz"
+  buttons — WebContainers can run the example servers in-browser, so live
+  demos need no hosted infrastructure.
+
+## Next — M6
+
+- **Channels** — the v2.x headline feature. Starts as RFC 0002: API
+  surface, the plugin vocabulary (RFC 0001 §4.6), and what it expects of
+  servers.
+- **Stress/soak harness.** Long-running chaos runs: server kill loops,
+  queue pressure at the bound, reconnect storms, memory growth over
+  hours. Durability claims should be measured, not asserted.
+
+## Later — unscheduled ideas
+
+- **Svelte binding** — the agreed fast-follow once there's demand
+  (RFC 0001 §8).
+- **AsyncAPI codegen** — generate a typed client from an AsyncAPI
+  document; core already has every seam it needs (RFC 0001 §9).
+- **OpenTelemetry pack** — a `durablews/otel` middleware + subscriber
+  over the existing seams; decide on demand (RFC 0001 §9 records the
+  caveats: no stable WS semantic conventions yet).
+- **socket.io codec** — wire-format interop with socket.io servers.
+- **Send-wrapper recipes** — debounce/batch/dedupe helpers composed in
+  front of `send()`; a docs recipes page or a tiny helpers module
+  (RFC 0001 §9).

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -50,7 +50,10 @@ export default defineConfig({
                 },
                 {
                     label: "Reference",
-                    items: [{ label: "API reference", slug: "reference/api" }],
+                    items: [
+                        { label: "API reference", slug: "reference/api" },
+                        { label: "Changelog", slug: "changelog" },
+                    ],
                 },
             ],
         }),

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -1,0 +1,18 @@
+---
+title: Changelog
+description: Release history for durablews, generated from changesets.
+---
+
+{/*
+  Rendered straight from the package's changesets-generated CHANGELOG.md
+  at build time — one source of truth, updated automatically by every
+  release. Do not write changelog content here.
+*/}
+
+import { Content as Changelog } from "../../../../packages/durablews/CHANGELOG.md";
+
+Every release is also published on
+[GitHub Releases](https://github.com/imnsco/DurableWS/releases) and follows
+[semver](https://semver.org/).
+
+<Changelog />

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -1,9 +1,14 @@
 # RFC 0001 — DurableWS v2 Architecture
 
-- **Status:** Draft
+- **Status:** Implemented (shipped as `durablews@2.0.0`, 2026-06-10)
 - **Author:** Nate Smith
 - **Created:** 2026-06-08
 - **Supersedes:** the v1.x design (published as `durablews@1.0.1`)
+
+> **This RFC is frozen.** It is the record of the v2 design and its
+> implementation (milestones M1–M4). Ongoing planning lives in
+> [ROADMAP.md](../ROADMAP.md); future architecture-level changes get a new
+> RFC — see [rfcs/README.md](README.md) for the process.
 
 ---
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,40 @@
+# RFCs
+
+Design documents for decisions that are **expensive to reverse** or whose
+**reasoning should be findable years later** — public API shape, packaging
+and export structure, protocol semantics. Routine features and fixes don't
+need an RFC: an issue and a PR are their own record (see
+[Proposing changes](../CONTRIBUTING.md#proposing-changes) in the
+contributing guide). The live plan for what's being built next is
+[ROADMAP.md](../ROADMAP.md).
+
+## Process
+
+1. Create `rfcs/NNNN-short-slug.md` using the next free number (four
+   digits, kebab-case slug) and the header block below.
+2. Open a PR. The PR discussion **is** the review — no separate forum, no
+   fixed comment window.
+3. When the PR merges, the RFC is **Accepted** and work can be scheduled.
+4. Keep the status current as work proceeds. Once the work ships, the RFC
+   becomes **Implemented** and is frozen: corrections and clarifications
+   only. New scope means a new RFC, not a reopened one.
+
+Header block:
+
+````md
+# RFC NNNN — Title
+
+- **Status:** Draft | Accepted | Implemented | Superseded
+- **Author:** …
+- **Created:** YYYY-MM-DD
+````
+
+An RFC that replaces an earlier one links it with `**Supersedes:**` in its
+header, and the replaced RFC's status becomes
+`Superseded (by [RFC NNNN](NNNN-short-slug.md))`.
+
+## Index
+
+| RFC                              | Title                     | Status      |
+| -------------------------------- | ------------------------- | ----------- |
+| [0001](0001-v2-architecture.md)  | DurableWS v2 Architecture | Implemented |


### PR DESCRIPTION
Implements the process skeleton agreed in discussion:

- **RFC 0001 → Implemented and frozen.** It remains the v2 design record; it stops accreting milestones.
- **`rfcs/README.md`** — the one-page RFC process: what merits an RFC (expensive-to-reverse decisions), the `Draft → Accepted → Implemented → Superseded` lifecycle, numbering, and an index.
- **CONTRIBUTING.md** — a *Proposing changes* section (PR / issue-first / RFC, by weight of change); the stale "v2 is under active redesign" heads-up replaced.
- **`ROADMAP.md`** — the live plan, taking over RFC 0001's tracker role: M5 (dynamic URL provider, middleware pack, examples-in-docs), M6 (channels — starts as RFC 0002 — and a stress/soak harness), and the unscheduled backlog from RFC 0001 §8/§9.
- **Docs `/changelog` page** — renders `packages/durablews/CHANGELOG.md` (changesets-generated) at build time: one source of truth, updates automatically with every release. RFCs deliberately stay GitHub-only (internal framing stays internal).

Docs build verified locally with the cross-package import.