### PR TITLE
docs: remove em-dashes from all prose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to DurableWS
 
-Thanks for your interest in contributing! DurableWS is being built in the open, and contributions — issues, docs, fixes, features — are welcome.
+Thanks for your interest in contributing! DurableWS is being built in the open, and contributions (issues, docs, fixes, features) are welcome.
 
 > **Where things stand:** v2 has shipped (`durablews@2.0.0`). [ROADMAP.md](ROADMAP.md) is the live plan; [RFC 0001](rfcs/0001-v2-architecture.md) records the architecture and why it is the way it is. Before starting non-trivial work, see [Proposing changes](#proposing-changes).
 
@@ -47,31 +47,31 @@ We use [changesets](https://github.com/changesets/changesets) for versioning and
 pnpm changeset
 ```
 
-Pick the appropriate semver bump and write a short, user-facing summary — it becomes the changelog entry verbatim. Tooling-only or docs-only changes that don't affect consumers don't need one. (Releases themselves are two merges; see [RELEASING.md](RELEASING.md).)
+Pick the appropriate semver bump and write a short, user-facing summary, it becomes the changelog entry verbatim. Tooling-only or docs-only changes that don't affect consumers don't need one. (Releases themselves are two merges; see [RELEASING.md](RELEASING.md).)
 
 ## Proposing changes
 
 Match the weight of the process to the weight of the change:
 
-- **Bug fixes and small improvements** — open a PR directly.
-- **Features** — open an issue first, so the approach is agreed before code is written. Scheduled work lives in [ROADMAP.md](ROADMAP.md).
-- **Architecture-level changes** — public API shape, packaging/exports, protocol semantics; anything expensive to reverse — start an RFC. The process is one page: [rfcs/README.md](rfcs/README.md).
+- **Bug fixes and small improvements**: open a PR directly.
+- **Features**: open an issue first, so the approach is agreed before code is written. Scheduled work lives in [ROADMAP.md](ROADMAP.md).
+- **Architecture-level changes** (public API shape, packaging/exports, protocol semantics; anything expensive to reverse) start an RFC. The process is one page: [rfcs/README.md](rfcs/README.md).
 
 ## Pull requests
 
 1. Branch from `main`.
 2. Make your change with tests and (if user-facing) a changeset.
-3. If your change completes or alters a roadmap item, update [ROADMAP.md](ROADMAP.md) in the same PR — tracker updates travel with the work.
+3. If your change completes or alters a roadmap item, update [ROADMAP.md](ROADMAP.md) in the same PR, tracker updates travel with the work.
 4. Ensure `pnpm verify` passes.
 5. Open a PR against `main` and fill out the template.
 
 ## Plugins & add-ons
 
-DurableWS keeps a small core and ships optional capabilities as **subpath exports** — named by what they are:
+DurableWS keeps a small core and ships optional capabilities as **subpath exports**: named by what they are:
 
-- **middleware** — cross-cutting behavior over the message pipeline (auth, logging, retry hooks)
-- **codecs** — the wire format (`encode`/`decode`), e.g. JSON (default), msgpack
-- **plugins** — add-ons that extend the client's public API (e.g. channels/presence)
+- **middleware**: cross-cutting behavior over the message pipeline (auth, logging, retry hooks)
+- **codecs**: the wire format (`encode`/`decode`), e.g. JSON (default), msgpack
+- **plugins**: add-ons that extend the client's public API (e.g. channels/presence)
 
 ### Naming convention for third-party packages
 

--- a/README.md
+++ b/README.md
@@ -5,23 +5,23 @@
 [![bundle size](https://img.shields.io/badge/core-%E2%89%A4%203%20KB%20brotli%20(CI--enforced)-blue)](packages/durablews/package.json)
 [![license](https://img.shields.io/badge/license-MPL--2.0-green)](LICENSE)
 
-> The WebSocket client that survives the real world — automatic reconnection, bounded queueing, and typed messages. Zero dependencies, built on the standard `WebSocket`, the same in every modern runtime (browser, Node ≥22, Deno, Bun, edge).
+> The WebSocket client that survives the real world, automatic reconnection, bounded queueing, and typed messages. Zero dependencies, built on the standard `WebSocket`, the same in every modern runtime (browser, Node ≥22, Deno, Bun, edge).
 
-> **v2.0 is out** — `npm install durablews`. See **[durablews.imns.co](https://durablews.imns.co)** for the docs, and [RFC 0001](rfcs/0001-v2-architecture.md) for the architecture and a live status tracker.
+> **v2.0 is out**: `npm install durablews`. See **[durablews.imns.co](https://durablews.imns.co)** for the docs, and [RFC 0001](rfcs/0001-v2-architecture.md) for the architecture and a live status tracker.
 
-The published library lives in **[`packages/durablews`](packages/durablews)** — see its [README](packages/durablews/README.md) for usage, the feature status, and requirements.
+The published library lives in **[`packages/durablews`](packages/durablews)**: see its [README](packages/durablews/README.md) for usage, the feature status, and requirements.
 
 ## Examples
 
 Runnable, in [`examples/`](examples/):
 
-- **[resilience-playground](examples/resilience-playground/)** — sabotage the server from the UI and watch the state machine, retry counter, and queue survive you. The flagship demo.
-- **[chat](examples/chat/)** — presence + typing indicators, implemented twice (Vue composable, React hook) against one server and one zod schema.
-- **[collab-notepad](examples/collab-notepad/)** — a raw-`WebSocket` collaborative editor made durable by swapping one import (`durablews/compat`).
+- **[resilience-playground](examples/resilience-playground/)**: sabotage the server from the UI and watch the state machine, retry counter, and queue survive you. The flagship demo.
+- **[chat](examples/chat/)**: presence + typing indicators, implemented twice (Vue composable, React hook) against one server and one zod schema.
+- **[collab-notepad](examples/collab-notepad/)**: a raw-`WebSocket` collaborative editor made durable by swapping one import (`durablews/compat`).
 
 ## Why
 
-socket.io and friends are heavy and predate Web Standards. DurableWS bets on the standard global `WebSocket` (now in every modern runtime), ships zero runtime dependencies, and makes durability — reconnection, queueing, idle detection — the default rather than something you bolt on. Extensibility comes from a middleware + codec pipeline, so custom wire formats, auth, and even a socket.io-compatibility layer are opt-in add-ons rather than core weight.
+socket.io and friends are heavy and predate Web Standards. DurableWS bets on the standard global `WebSocket` (now in every modern runtime), ships zero runtime dependencies, and makes durability (reconnection, queueing, idle detection) the default rather than something you bolt on. Extensibility comes from a middleware + codec pipeline, so custom wire formats, auth, and even a socket.io-compatibility layer are opt-in add-ons rather than core weight.
 
 ## Repository layout
 
@@ -53,11 +53,11 @@ Commits are formatted automatically by a [lefthook](https://lefthook.dev) pre-co
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) — including the naming convention for third-party plugins. By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md), including the naming convention for third-party plugins. By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Security
 
-Please report vulnerabilities responsibly — see [SECURITY.md](SECURITY.md).
+Please report vulnerabilities responsibly, see [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,13 @@
 # Releasing
 
-How a `durablews` release works end to end. Publishing is fully automated —
-npm **trusted publishing** via OIDC, so no npm token exists anywhere — and a
+How a `durablews` release works end to end. Publishing is fully automated,
+npm **trusted publishing** via OIDC, so no npm token exists anywhere, and a
 release is exactly **two PR merges**.
 
 ## The flow
 
 1. Feature PRs that affect the published package include a changeset
-   (`pnpm changeset`). The summary you write there is the changelog entry —
+   (`pnpm changeset`). The summary you write there is the changelog entry,
    write it user-facing.
 2. On every merge to `main`, `release.yml` runs. While changesets are
    pending it opens (or force-updates) the **"Version Packages" PR**
@@ -20,7 +20,7 @@ release is exactly **two PR merges**.
 
 ## Mechanics worth knowing
 
-- **npm auth:** Trusted Publisher (OIDC) — `imnsco/DurableWS` →
+- **npm auth:** Trusted Publisher (OIDC), `imnsco/DurableWS` →
   `release.yml` → environment `production`, configured on the npm package
   settings. Nothing to rotate. Trusted publishing needs npm ≥ 11.5.1, so
   the workflow installs `npm@latest` before publishing.
@@ -31,7 +31,7 @@ release is exactly **two PR merges**.
   credentials checkout persists) and the changesets step's `GITHUB_TOKEN`
   env (PR creation via the API). Without it the Version PR branch is
   pushed by the built-in `GITHUB_TOKEN`, whose events never trigger
-  workflows — the PR's required checks would sit "expected" forever.
+  workflows, the PR's required checks would sit "expected" forever.
 - Every merge to `main` force-rebuilds the open Version PR branch; its
   checks re-run automatically.
 
@@ -39,7 +39,7 @@ release is exactly **two PR merges**.
 
 - **Version PR has no checks:** `RELEASE_TOKEN` is missing, expired, or
   was removed from one of its two spots in `release.yml`. Stopgap while
-  fixing the token: close and reopen the PR — a real-user event
+  fixing the token: close and reopen the PR, a real-user event
   re-triggers CI.
 - **Publish fails on auth:** the Trusted Publisher config on npm must
   match the workflow exactly (owner/repo, workflow filename, environment

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,23 +3,23 @@
 The live plan for DurableWS, updated as work lands. Ordering within a
 section is by leverage, not commitment. Scheduled items become GitHub
 issues when work starts; architecture-level items get an RFC first (see
-[rfcs/README.md](rfcs/README.md)). The v2 design itself — milestones
-M1–M4, shipped as `durablews@2.0.0` — is recorded in
+[rfcs/README.md](rfcs/README.md)). The v2 design itself, milestones
+M1-M4, shipped as `durablews@2.0.0`, is recorded in
 [RFC 0001](rfcs/0001-v2-architecture.md); milestone numbering continues
 from there.
 
-## Now — M5: adoption follow-through
+## Now, M5: adoption follow-through
 
 - **Dynamic URL provider.** Accept `url` as a sync or async function,
-  re-resolved on every (re)connect attempt — the token-in-URL auth
+  re-resolved on every (re)connect attempt, the token-in-URL auth
   pattern. Closes the first concession in the docs'
   [comparison page](https://durablews.imns.co/comparison/).
-- **Built-in middleware pack — RFC 0002.** A `durablews/middleware`
-  subpath: named exports, side-effect-free, tree-shakable — middleware you
+- **Built-in middleware pack, RFC 0002.** A `durablews/middleware`
+  subpath: named exports, side-effect-free, tree-shakable, middleware you
   don't import costs zero bundle bytes, enforced with a dedicated
   size-limit budget in CI. The RFC's spine is the public **middleware
   authoring contract** (the API third-party `durablews-plugin-*` middleware
-  write against — the part expensive to reverse); the in-box set and the
+  write against, the part expensive to reverse); the in-box set and the
   tree-shaking guarantee hang off it. Production-grounded candidate set
   (still to be confirmed): **auth/token-refresh** (the canonical async
   outbound case), **logger/devtools with redaction**, **idempotency/dedup**
@@ -37,15 +37,15 @@ from there.
 - **Examples in the docs.** One page per runnable example (its thesis,
   the load-bearing code excerpt, run instructions, GitHub link) plus an
   Examples card on the docs homepage. Follow-up: "Open in StackBlitz"
-  buttons — WebContainers can run the example servers in-browser, so live
+  buttons, WebContainers can run the example servers in-browser, so live
   demos need no hosted infrastructure.
 
-## Next — M6
+## Next, M6
 
-- **Channels** — the v2.x headline feature. Starts as RFC 0003: the
+- **Channels**: the v2.x headline feature. Starts as RFC 0003: the
   channels / actions / messages API surface, the plugin vocabulary
   (RFC 0001 §4.6), and what it expects of servers. Core to the design (not
-  an add-on): a **per-topic state cache** — a hash map keyed by channel,
+  an add-on): a **per-topic state cache**: a hash map keyed by channel,
   so subscriptions to the same topic dedup, the last value is retained,
   and a late subscriber gets current state on subscribe, then live
   updates. This is the TanStack-Query-shaped piece; channels make it
@@ -53,24 +53,24 @@ from there.
   Message acks and sequence-gap/replay are plugin-adjacent and likely fold
   in here or follow it.
 
-## Later — unscheduled ideas
+## Later, unscheduled ideas
 
-- **Svelte binding** — the agreed fast-follow once there's demand
+- **Svelte binding**: the agreed fast-follow once there's demand
   (RFC 0001 §8).
-- **AsyncAPI codegen** — generate a typed client from an AsyncAPI
+- **AsyncAPI codegen**: generate a typed client from an AsyncAPI
   document; core already has every seam it needs (RFC 0001 §9).
-- **OpenTelemetry pack** — a `durablews/otel` middleware + subscriber
+- **OpenTelemetry pack**: a `durablews/otel` middleware + subscriber
   over the existing seams; decide on demand (RFC 0001 §9 records the
   caveats: no stable WS semantic conventions yet).
-- **socket.io codec** — wire-format interop with socket.io servers.
-- **Send-wrapper recipes** — debounce/batch/dedupe helpers composed in
+- **socket.io codec**: wire-format interop with socket.io servers.
+- **Send-wrapper recipes**: debounce/batch/dedupe helpers composed in
   front of `send()`; a docs recipes page or a tiny helpers module
   (RFC 0001 §9).
-- **WHATWG conformance audit** — measure `durablews/compat` against the
+- **WHATWG conformance audit**: measure `durablews/compat` against the
   [WHATWG WebSocket standard](https://websockets.spec.whatwg.org/) and turn
   the result into a conformance test suite; sharpens the compat layer's
   known-deviations table. Orthogonal to middleware.
 - **Stress/soak harness.** Long-running chaos runs: server kill loops,
   queue pressure at the bound, reconnect storms, memory growth over hours.
   Durability claims should be measured, not asserted. Committed but lowest
-  priority — runs last, after the user-facing work above.
+  priority, runs last, after the user-facing work above.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,9 +16,9 @@ The legacy `1.x` line is not maintained.
 
 Instead, use one of the following private channels:
 
-1. **GitHub private vulnerability reporting** — preferred. Open a report via the
+1. **GitHub private vulnerability reporting**: preferred. Open a report via the
    repository's **Security → Report a vulnerability** tab.
-2. **Email** — `contact@imns.co`.
+2. **Email**: `contact@imns.co`.
 
 Please include enough detail to reproduce: affected version/commit, a
 description of the issue, and a proof of concept if possible.

--- a/docs/src/content/docs/changelog.mdx
+++ b/docs/src/content/docs/changelog.mdx
@@ -5,7 +5,7 @@ description: Release history for durablews, generated from changesets.
 
 {/*
   Rendered straight from the package's changesets-generated CHANGELOG.md
-  at build time — one source of truth, updated automatically by every
+  at build time, one source of truth, updated automatically by every
   release. Do not write changelog content here.
 */}
 

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -5,24 +5,24 @@ description: An honest comparison with reconnecting-websocket, partysocket, and 
 
 The niche DurableWS lives in is *durable clients over the standard
 `WebSocket`*. Two libraries already live there, and one giant defines the
-category's expectations from outside it. Here's where we genuinely differ —
+category's expectations from outside it. Here's where we genuinely differ,
 including the places the alternatives are ahead today.
 
 ## The landscape
 
-- **[reconnecting-websocket](https://github.com/pladaria/reconnecting-websocket)** —
+- **[reconnecting-websocket](https://github.com/pladaria/reconnecting-websocket)**,
   the long-standing default for "a WebSocket that reconnects". Its last
   release was in 2020; dozens of issues and PRs sit open.
-- **[partysocket](https://www.npmjs.com/package/partysocket)** — the
+- **[partysocket](https://www.npmjs.com/package/partysocket)**: the
   actively-maintained fork (PartyKit / Cloudflare), with bugfixes, pending
   PRs, multi-platform support, and a React hook. If you want a maintained
-  drop-in `WebSocket` class today, this is the one to beat — and the one we
+  drop-in `WebSocket` class today, this is the one to beat, and the one we
   benchmark ourselves against.
-- **socket.io** — a different category. Its gravity is server-side (rooms,
+- **socket.io**: a different category. Its gravity is server-side (rooms,
   namespaces, broadcast), its protocol requires a socket.io server, and its
   client can't talk to a plain WebSocket server. If you control the server
   and want rooms out of the box, use socket.io. If you have a plain
-  WebSocket endpoint and need a client that survives the real world — that's
+  WebSocket endpoint and need a client that survives the real world, that's
   this niche.
 
 ## Feature comparison
@@ -49,7 +49,7 @@ including the places the alternatives are ahead today.
 **Queueing you can reason about.** All three buffer messages while
 disconnected. The difference is what happens at the edges: DurableWS's queue
 is bounded (256 by default), drops the oldest when full, and **every** dropped
-message — overflow or connection-death — fires a `drop` event carrying exactly
+message (overflow or connection-death) fires a `drop` event carrying exactly
 what you passed to `send()`. An unbounded silent buffer is a memory leak with
 a delay; a capped silent buffer is data loss with no witness.
 
@@ -71,10 +71,10 @@ alternatives hand you `MessageEvent["data"]`.
 Honesty over marketing:
 
 - **Dynamic URL resolution.** partysocket accepts `url` as a sync or async
-  function, re-resolved per reconnect — handy for token-in-URL auth schemes.
+  function, re-resolved per reconnect, handy for token-in-URL auth schemes.
   DurableWS handles token freshness via outbound middleware, but per-connect
   URL re-resolution isn't built yet.
 - **Years in production.** The reconnecting-websocket lineage has carried an
   enormous amount of traffic. DurableWS 2.0 is new, with a thorough test
-  pyramid (unit, integration, real-browser e2e) — but production-miles are
+  pyramid (unit, integration, real-browser e2e), but production-miles are
   earned, not claimed.

--- a/docs/src/content/docs/frameworks/react.md
+++ b/docs/src/content/docs/frameworks/react.md
@@ -1,10 +1,10 @@
 ---
 title: React
-description: The useWebSocket hook — DurableWS state in React, built on useSyncExternalStore.
+description: The useWebSocket hook, DurableWS state in React, built on useSyncExternalStore.
 ---
 
 DurableWS ships a first-class React hook in the box: `durablews/react`.
-No extra package — React is an *optional* peer dependency, so installing
+No extra package, React is an *optional* peer dependency, so installing
 `durablews` without React never warns, and the hook only loads when you
 import it. React 18+ is required.
 
@@ -39,9 +39,9 @@ Everything durable-by-default applies: the connection reconnects with
 full-jitter backoff, `send()` queues while disconnected and flushes on open,
 and `state` walks through `"reconnecting"` so your UI can show it.
 
-The hook is built on `useSyncExternalStore` — the client's `subscribe()` /
+The hook is built on `useSyncExternalStore`, the client's `subscribe()` /
 `getState()` pair is exactly that contract, with referentially stable
-snapshots — so it is concurrent-rendering-safe and Strict Mode's double-effect
+snapshots, so it is concurrent-rendering-safe and Strict Mode's double-effect
 mount/unmount cycle is handled.
 
 ## What you get back
@@ -56,7 +56,7 @@ mount/unmount cycle is handled.
 | `send` / `connect` / `close` | functions | Proxies to the client |
 | `client` | `WebSocketClient` | The full client, for everything else (`on()`, `use()`, …) |
 
-`lastMessage` keeps only the latest message — DurableWS never accumulates
+`lastMessage` keeps only the latest message, DurableWS never accumulates
 message history. To process every message, subscribe on the client in an
 effect:
 
@@ -64,7 +64,7 @@ effect:
 const { client } = useWebSocket({ url });
 
 useEffect(() => {
-    // on() returns its own unsubscribe — ready-made effect cleanup.
+    // on() returns its own unsubscribe, ready-made effect cleanup.
     return client.on("message", (msg) => {
         // every message, not just the latest
     });
@@ -74,7 +74,7 @@ useEffect(() => {
 ## Typed messages
 
 Pass a [Standard Schema](https://standardschema.dev) (zod, valibot, arktype, …)
-and `lastMessage` is fully typed — plus every inbound message is validated at
+and `lastMessage` is fully typed, plus every inbound message is validated at
 runtime:
 
 ```tsx
@@ -92,17 +92,17 @@ function Chat() {
 }
 ```
 
-The config is captured on first render — changing it later does not recreate
+The config is captured on first render, changing it later does not recreate
 the client, so an inline config object is fine (no `useMemo` needed).
 
 ## Sharing one connection across components
 
 Pass an **existing client** instead of a config and the hook only observes
-it — it never connects or closes a client it was handed. This is the pattern
+it, it never connects or closes a client it was handed. This is the pattern
 for an app-wide connection used by many components:
 
 ```tsx
-// src/ws.ts — the app owns this client
+// src/ws.ts, the app owns this client
 import { defineClient } from "durablews";
 
 export const ws = defineClient({ url: "wss://example.com/socket" });

--- a/docs/src/content/docs/frameworks/vue.md
+++ b/docs/src/content/docs/frameworks/vue.md
@@ -1,10 +1,10 @@
 ---
 title: Vue
-description: The useWebSocket composable — reactive DurableWS state for Vue 3.
+description: The useWebSocket composable, reactive DurableWS state for Vue 3.
 ---
 
 DurableWS ships a first-class Vue 3 composable in the box: `durablews/vue`.
-No extra package — Vue is an *optional* peer dependency, so installing
+No extra package, Vue is an *optional* peer dependency, so installing
 `durablews` without Vue never warns, and the composable only loads when you
 import it.
 
@@ -49,7 +49,7 @@ and `state` walks through `reconnecting` so your UI can show it.
 | `send` / `connect` / `close` | functions | Proxies to the client |
 | `client` | `WebSocketClient` | The full client, for everything else (`on()`, `use()`, …) |
 
-`lastMessage` keeps only the latest message — DurableWS never accumulates
+`lastMessage` keeps only the latest message, DurableWS never accumulates
 message history. To process every message, handle the event on the client:
 
 ```ts
@@ -62,7 +62,7 @@ client.on("message", (msg) => {
 ## Typed messages
 
 Pass a [Standard Schema](https://standardschema.dev) (zod, valibot, arktype, …)
-and `lastMessage` is fully typed — plus every inbound message is validated at
+and `lastMessage` is fully typed, plus every inbound message is validated at
 runtime:
 
 ```vue
@@ -83,11 +83,11 @@ const { lastMessage } = useWebSocket({
 ## Sharing one connection across components
 
 Pass an **existing client** instead of a config and the composable only
-observes it — it never connects or closes a client it was handed. This is the
+observes it, it never connects or closes a client it was handed. This is the
 pattern for an app-wide connection used by many components:
 
 ```ts
-// src/ws.ts — the app owns this client
+// src/ws.ts, the app owns this client
 import { defineClient } from "durablews";
 
 export const ws = defineClient({ url: "wss://example.com/socket" });

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -8,7 +8,7 @@ description: Install DurableWS and open your first connection.
 DurableWS targets the standard global `WebSocket` with **zero runtime
 dependencies**:
 
-- **Node.js ≥ 22** — the first release with the global `WebSocket` available
+- **Node.js ≥ 22**: the first release with the global `WebSocket` available
   unflagged (there is no `ws` dependency, by design).
 - Any modern runtime with a global `WebSocket`: current browsers, Deno, Bun,
   and Cloudflare Workers.
@@ -39,8 +39,8 @@ client.close();
 
 ## Typed (and validated) messages
 
-Pass any [Standard Schema](https://standardschema.dev) — zod, valibot,
-arktype, … — and you get **both** static types and runtime validation, with
+Pass any [Standard Schema](https://standardschema.dev), zod, valibot,
+arktype, …, and you get **both** static types and runtime validation, with
 zero added dependencies:
 
 ```ts
@@ -55,7 +55,7 @@ const client = defineClient({
 });
 
 client.on("message", (msg) => {
-    // msg is { type: string; body: string } — inferred from the schema,
+    // msg is { type: string; body: string }, inferred from the schema,
     // and every inbound message was validated at runtime.
 });
 
@@ -77,14 +77,14 @@ const client = defineClient<Incoming, Outgoing>({ url });
 
 ## Middleware
 
-Middleware intercepts messages on their way through the client — in both
+Middleware intercepts messages on their way through the client, in both
 directions. A bare function is **inbound** middleware; the object form
 registers per direction:
 
 ```ts
 client.use({
     outbound: async (ctx, next) => {
-        // Attach a token that is fresh when the message actually goes out —
+        // Attach a token that is fresh when the message actually goes out,
         // outbound middleware runs at transmission time, so even a message
         // queued across a reconnect gets a current token.
         ctx.data = { ...ctx.data, token: await getFreshToken() };
@@ -95,26 +95,26 @@ client.use({
 
 Outbound middleware may be async: the outbound path preserves `send()` order,
 so messages never overtake each other (which also means a slow middleware
-delays everything behind it — pacing the stream is a feature, but per-key
+delays everything behind it, pacing the stream is a feature, but per-key
 debounce/batching belongs in a wrapper *in front of* `send()`, not in the
-pipeline). Returning without calling `next()` deliberately drops the message —
+pipeline). Returning without calling `next()` deliberately drops the message,
 no `drop` event, that's policy, not loss. A throw fails only that message (it
 surfaces as an `error` event) and later messages continue. Heartbeat pings
 bypass outbound middleware entirely.
 
 ## What works today
 
-- **Automatic reconnection, on by default** — full-jitter exponential backoff
+- **Automatic reconnection, on by default**: full-jitter exponential backoff
   with unlimited retries. An unexpected disconnect transparently recovers; a
   `reconnecting` event (`{ attempt, delay }`) keeps your UI informed. Tune or
   disable via the `reconnect` option (`baseDelay`, `factor`, `maxDelay`,
   `jitter`, `maxRetries`, `shouldReconnect`, or `reconnect: false`).
-- **Message queueing while disconnected, on by default** — `send()` during
+- **Message queueing while disconnected, on by default**: `send()` during
   `connecting`/`reconnecting` queues (bounded, 256 by default) and flushes in
   order when the socket opens. Dropped messages are never silent: every one
   fires a `drop` event (`{ data, reason }`). Tune via `queue: { maxSize }` or
   restore throw-when-not-open with `queue: false`.
-- **Heartbeat / idle detection, opt-in** — set
+- **Heartbeat / idle detection, opt-in**: set
   `heartbeat: { interval, message?, timeout? }` and the client pings while
   open; if no inbound traffic answers within `timeout`, the link is declared
   dead (close code `4408`) and the normal reconnect machinery takes over.
@@ -128,20 +128,20 @@ bypass outbound middleware entirely.
 - A pluggable wire-format codec (`codec` option; JSON by default)
 - **Typed + validated messages** via any Standard Schema (`schema` option),
   or plain generics (`defineClient<In, Out>`)
-- A message middleware pipeline (`use()`) — **inbound and outbound**, with
+- A message middleware pipeline (`use()`), **inbound and outbound**, with
   outbound running at transmission time, async-capable with strict
   `send()`-order preservation; plus an opt-in `pingpong` keepalive
-- **Framework bindings in the box** — a [Vue composable](/frameworks/vue/) and
+- **Framework bindings in the box**: a [Vue composable](/frameworks/vue/) and
   a [React hook](/frameworks/react/) (`durablews/vue`, `durablews/react`) with
   reactive connection state and automatic cleanup; the frameworks are optional
   peers, so core installs never warn
-- **A drop-in `WebSocket` class** —
+- **A drop-in `WebSocket` class**,
   [`durablews/compat`](/guides/compat/): swap it in where a socket goes (or
   inject it as a library's `webSocketImpl`) and get the durable core
   underneath, with a published known-deviations table
 
 :::note[`connect()` and unlimited retries]
-`connect()` resolves on the first successful open — including when that open is
+`connect()` resolves on the first successful open, including when that open is
 a successful retry. Under the default `maxRetries: Infinity` it never rejects:
 against a down host it stays pending while the client keeps trying. That is the
 durable-by-default contract. Need a deadline? Set a finite `maxRetries` or race
@@ -150,6 +150,6 @@ it: `Promise.race([client.connect(), timeout(10_000)])`.
 
 ## On the roadmap
 
-Channels are the headline of v2.x — see the
+Channels are the headline of v2.x, see the
 [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
 for the full plan and status.

--- a/docs/src/content/docs/guides/codecs.md
+++ b/docs/src/content/docs/guides/codecs.md
@@ -1,10 +1,10 @@
 ---
 title: Codecs
-description: The wire-format seam — JSON by default, swap in anything.
+description: The wire-format seam, JSON by default, swap in anything.
 ---
 
 Every message crosses `encode`/`decode`, so the wire format is a first-class
-config option — not middleware:
+config option, not middleware:
 
 ```ts
 interface Codec {
@@ -20,10 +20,10 @@ the codec contract can never drift looser than what the socket accepts.
 
 With no `codec` configured, `jsonCodec` applies:
 
-- **encode** — strings pass through as-is; binary (`ArrayBuffer`,
+- **encode**: strings pass through as-is; binary (`ArrayBuffer`,
   `ArrayBufferView`, `Blob`) passes through untouched; everything else is
   `JSON.stringify`-ed.
-- **decode** — strings are `JSON.parse`-d with a safe fallback to the raw
+- **decode**: strings are `JSON.parse`-d with a safe fallback to the raw
   string when they aren't JSON; binary frames pass through untouched.
 
 That means `client.send({ type: "hello" })` and `client.send(bytes)` both do
@@ -46,7 +46,7 @@ const client = defineClient({ url, codec: msgpackCodec });
 
 :::tip[Binary frames arrive as `Blob` in browsers]
 Browsers deliver binary WebSocket frames as `Blob` by default. If your codec
-expects `ArrayBuffer`, handle both — or decode the `Blob` asynchronously in an
+expects `ArrayBuffer`, handle both, or decode the `Blob` asynchronously in an
 inbound middleware instead, since `decode` is synchronous.
 :::
 
@@ -60,7 +60,7 @@ outbound:  send() → [queue] → outbound middleware → codec.encode → socke
 Two consequences worth knowing:
 
 - [Schema validation](/getting-started/#typed-and-validated-messages) runs on
-  *decoded* values — your schema describes application messages, not wire
+  *decoded* values, your schema describes application messages, not wire
   bytes.
 - Outbound middleware runs *before* encode, so middleware transforms plain
   values and the codec owns serialization. A token-stamping middleware and a

--- a/docs/src/content/docs/guides/compat.md
+++ b/docs/src/content/docs/guides/compat.md
@@ -1,15 +1,15 @@
 ---
 title: Drop-in compat
-description: A WebSocket-shaped class over the durable core — durablews/compat.
+description: A WebSocket-shaped class over the durable core, durablews/compat.
 ---
 
 `durablews/compat` exports a class shaped like the native `WebSocket`, with
 the durable core underneath: automatic reconnection with full-jitter backoff,
 bounded queueing, opt-in heartbeat. It exists for two audiences:
 
-1. **App code that constructs sockets directly** — the
+1. **App code that constructs sockets directly**: the
    `reconnecting-websocket` / `partysocket` crowd. Migration is one line.
-2. **Libraries with a `webSocketImpl`-style injection point** — graphql-ws,
+2. **Libraries with a `webSocketImpl`-style injection point**: graphql-ws,
    y-websocket, realtime SDKs. Inject durability into tools that never learn
    durablews exists.
 
@@ -48,11 +48,11 @@ const provider = new WebsocketProvider(url, room, doc, {
 ```
 
 :::caution[The layering rule: one reconnector per stack]
-Libraries with **stateful sync protocols** — y-websocket, graphql-ws —
+Libraries with **stateful sync protocols** (y-websocket, graphql-ws)
 implement their *own* reconnection, because they must redo a handshake on
 every new connection. Injecting a socket that also reconnects puts two
 recovery layers in a fight (the library abandons the socket on `close` while
-the socket revives itself — zombie connections). When the consuming library
+the socket revives itself, zombie connections). When the consuming library
 reconnects, hand it a wrapper with ours off:
 
 ```ts
@@ -63,8 +63,8 @@ class PipeSocket extends DurableWebSocket {
 }
 ```
 
-Compat's sweet spot is code that treats the socket as a **plain pipe** —
-hand-rolled WebSocket code, thin SDKs without recovery logic — where the
+Compat's sweet spot is code that treats the socket as a **plain pipe**,
+hand-rolled WebSocket code, thin SDKs without recovery logic, where the
 one-line swap delivers the full durability story. See the
 [collab-notepad example](https://github.com/imnsco/DurableWS/tree/main/examples/collab-notepad).
 :::
@@ -72,7 +72,7 @@ one-line swap delivers the full durability story. See the
 ## Tuning the durability
 
 The third constructor argument takes the durablews config (everything except
-`codec` and `schema` — compat is deliberately wire-faithful, byte in, byte
+`codec` and `schema`, compat is deliberately wire-faithful, byte in, byte
 out):
 
 ```ts
@@ -97,7 +97,7 @@ deviations, exhaustively:
 
 | Behavior | Native `WebSocket` | `durablews/compat` |
 | --- | --- | --- |
-| `readyState` across disconnects | one-shot: never leaves `CLOSED` | returns to `CONNECTING` during automatic reconnects — the entire point |
+| `readyState` across disconnects | one-shot: never leaves `CLOSED` | returns to `CONNECTING` during automatic reconnects, the entire point |
 | `send()` while `CONNECTING` | throws `InvalidStateError` | **queues**, flushes in order on open |
 | `close` events | once, at the end | once per dropped connection (each followed by reconnection) |
 | `protocol` / `extensions` | negotiated values | always `""` |
@@ -106,5 +106,5 @@ deviations, exhaustively:
 | `send()` after `close()` | silently discarded | silently discarded (matched) |
 
 If one of these deviations matters to your integration, use the primary
-[`defineClient`](/reference/api/) API instead — it doesn't pretend to be a
+[`defineClient`](/reference/api/) API instead, it doesn't pretend to be a
 one-shot socket, so none of these tensions exist there.

--- a/docs/src/content/docs/guides/durability.md
+++ b/docs/src/content/docs/guides/durability.md
@@ -1,6 +1,6 @@
 ---
 title: Durability tuning
-description: Reconnection, queueing, and heartbeat — the defaults, and every knob.
+description: Reconnection, queueing, and heartbeat, the defaults, and every knob.
 ---
 
 DurableWS is durable by default: reconnection and queueing are **on** with
@@ -40,13 +40,13 @@ const client = defineClient({
 Disable entirely with `reconnect: false`.
 
 Each scheduled retry fires a `reconnecting` event (`{ attempt, delay }`), and
-`retryAttempt` appears in `getState()` — show it in your UI. A successful open
+`retryAttempt` appears in `getState()`, show it in your UI. A successful open
 resets the attempt counter.
 
 ### `connect()` under unlimited retries
 
-`connect()` resolves on the **first successful open** — including when that
-open is a successful retry — and rejects only on *terminal* failure (retries
+`connect()` resolves on the **first successful open**: including when that
+open is a successful retry, and rejects only on *terminal* failure (retries
 exhausted, a `shouldReconnect` veto, or `close()` before the first open).
 Under the default `maxRetries: Infinity` it therefore **never rejects**:
 against a down host it stays pending while the client keeps trying. Need a
@@ -76,12 +76,12 @@ reconnect: {
 ## Queueing
 
 `send()` while `connecting` or `reconnecting` **queues** the message and
-flushes the backlog, in order, the moment the socket opens — before the `open`
+flushes the backlog, in order, the moment the socket opens, before the `open`
 event fires, so queued messages precede anything an open-handler sends.
 
 The queue is **bounded** (default `256`) with a **drop-oldest** policy, and a
 drop is never silent: every dropped message fires a `drop` event carrying the
-exact value you passed to `send()` and the reason — `"overflow"` (queue was
+exact value you passed to `send()` and the reason, `"overflow"` (queue was
 full) or `"close"` (the connection ended with messages still waiting).
 
 ```ts
@@ -95,14 +95,14 @@ client.on("drop", ({ data, reason }) => {
 `send()` still throws in states where no open is coming (`idle`, `closing`,
 `closed`), and always when `queue: false`.
 
-The queue stores the **raw values** you passed to `send()` — encoding (and
+The queue stores the **raw values** you passed to `send()`, encoding (and
 outbound middleware) run at transmission time, so a message queued across a
 reconnect goes out with, e.g., a token that is fresh when it actually leaves.
 
 ## Heartbeat
 
 Opt-in, because it requires a server that answers (or talks regularly for its
-own reasons) — an app-level contract the library can't assume:
+own reasons), an app-level contract the library can't assume:
 
 ```ts
 const client = defineClient({
@@ -116,13 +116,13 @@ const client = defineClient({
 ```
 
 While open, the client sends `message` every `interval`. **Any inbound frame**
-counts as liveness — a busy connection never pays for explicit pongs. If
+counts as liveness, a busy connection never pays for explicit pongs. If
 nothing arrives within `timeout` of a ping, the link is declared dead: an
 `error` is emitted, the socket is closed with the app-reserved code **4408**
 (exported as `HEARTBEAT_TIMEOUT_CODE`), and the close flows into the normal
 reconnect machinery.
 
-Heartbeat pings bypass outbound middleware — they are transport-level
+Heartbeat pings bypass outbound middleware, they are transport-level
 liveness, not app messages.
 
 ## Observing all of it
@@ -135,6 +135,6 @@ const unsubscribe = client.subscribe(() => {
 });
 ```
 
-Snapshots are frozen and referentially stable between changes — see the
+Snapshots are frozen and referentially stable between changes, see the
 [Vue](/frameworks/vue/) and [React](/frameworks/react/) bindings, which are
 built on exactly this pair.

--- a/docs/src/content/docs/guides/middleware.md
+++ b/docs/src/content/docs/guides/middleware.md
@@ -1,6 +1,6 @@
 ---
 title: Middleware
-description: Intercept messages in both directions — auth, logging, filtering, transforms.
+description: Intercept messages in both directions, auth, logging, filtering, transforms.
 ---
 
 Middleware intercepts messages flowing through the client. It follows the
@@ -18,7 +18,7 @@ client.use({ inbound: logIn, outbound: logOut });    // one logical middleware,
                                                      // both directions
 ```
 
-Middleware never adds client API — that's the [vocabulary](/reference/api/)
+Middleware never adds client API, that's the [vocabulary](/reference/api/)
 boundary between middleware and plugins.
 
 ## Inbound
@@ -34,7 +34,7 @@ client.use((ctx, next) => {
 });
 ```
 
-Short-circuiting suppresses the `message` event — useful for protocol frames
+Short-circuiting suppresses the `message` event, useful for protocol frames
 your handlers shouldn't see. The built-in `pingpong` middleware does exactly
 this: auto-replies to server pings without bubbling them.
 
@@ -45,7 +45,7 @@ client.use(pingpong);
 
 ## Outbound
 
-Runs at **transmission time** — after the queue, before `codec.encode`. The
+Runs at **transmission time**: after the queue, before `codec.encode`. The
 flagship use case is auth:
 
 ```ts
@@ -60,17 +60,17 @@ client.use({
 Transmission-time execution is a durability feature: a message queued across a
 30-second reconnect is stamped with a token that is fresh *when it actually
 goes out*, not when you called `send()`. It also means `drop` events always
-carry the raw value you passed to `send()` — never a half-transformed one.
+carry the raw value you passed to `send()`, never a half-transformed one.
 
 ### Ordering (and its honest cost)
 
 Outbound middleware may be async, and the outbound path is **serialized**:
 messages reach the socket in `send()` order even while an earlier message's
 middleware awaits. When nothing is in flight and the chain is synchronous,
-`send()` stays fully synchronous — zero overhead.
+`send()` stays fully synchronous, zero overhead.
 
 The flip side: a middleware that delays one message delays everything behind
-it (head-of-line). That's correct for the things middleware is for — pacing
+it (head-of-line). That's correct for the things middleware is for, pacing
 the stream *means* delaying it; a token refresh blocking sends is what
 freshness requires. Policies that want to selectively delay or collapse
 *specific* messages (per-key debounce, batching) inherently want reordering,
@@ -80,12 +80,12 @@ which the pipeline refuses. Compose those in front of `send()` instead:
 const sendTyping = debounce((s) => client.send(s), 300);
 ```
 
-Same composability, different layer — and unrelated messages never wait.
+Same composability, different layer, and unrelated messages never wait.
 
 ### Failure semantics
 
 - **Short-circuit** (returning without `next()`) means *deliberately not
-  sent*. No `drop` event — `drop` means the library couldn't deliver
+  sent*. No `drop` event, `drop` means the library couldn't deliver
   something; this is your policy choosing not to.
 - **A throw or rejection** surfaces as an `error` event and skips **only that
   message**; everything behind it continues.

--- a/docs/src/content/docs/guides/migrating-from-v1.md
+++ b/docs/src/content/docs/guides/migrating-from-v1.md
@@ -4,7 +4,7 @@ description: What changed between durablews 1.x and 2.0.
 ---
 
 v2 is a ground-up rewrite. v1's README advertised durability features the code
-didn't implement; v2 implements them. The API breaks — deliberately and once.
+didn't implement; v2 implements them. The API breaks, deliberately and once.
 
 ## The store is gone
 
@@ -12,7 +12,7 @@ v1 was a Redux-style store: `defineStore`, `dispatch`, `defineAction`,
 `composeActions`, reducers over connection state. All of it is removed. The
 connection lifecycle is now a typed finite state machine the library owns, and
 **messages are never accumulated in state** (v1's default handler retained
-every message forever — an unbounded leak).
+every message forever, an unbounded leak).
 
 ```ts
 // v1
@@ -25,7 +25,7 @@ await client.connect();
 ```
 
 If you used the store for app state: deliver messages into your own state
-tool (a `message` handler that writes to your store of choice) — core stays
+tool (a `message` handler that writes to your store of choice), core stays
 out of app state by design.
 
 ## No more singleton
@@ -44,8 +44,8 @@ export const ws = defineClient({ url });
 | v1 | v2 |
 | --- | --- |
 | `connected` | `open` |
-| `closed` (never fired — the v1 bug) | `close` |
-| — | `statechange`, `reconnecting`, `drop` |
+| `closed` (never fired, the v1 bug) | `close` |
+|, | `statechange`, `reconnecting`, `drop` |
 
 ```ts
 client.on("open", () => {});

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: DurableWS
-description: A resilient, zero-dependency WebSocket client for TypeScript — durable by default.
+description: A resilient, zero-dependency WebSocket client for TypeScript, durable by default.
 template: splash
 hero:
-  tagline: The WebSocket client that survives the real world — automatic reconnection, bounded queueing, and typed messages. Zero dependencies, every modern runtime.
+  tagline: The WebSocket client that survives the real world, automatic reconnection, bounded queueing, and typed messages. Zero dependencies, every modern runtime.
   actions:
     - text: Get started
       link: /getting-started/
@@ -23,7 +23,7 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 <CardGrid stagger>
 	<Card title="Durable by default" icon="random">
 		Automatic reconnection with full-jitter backoff and bounded message
-		queueing — on out of the box. Opt-in heartbeat closes quietly-dead
+		queueing, on out of the box. Opt-in heartbeat closes quietly-dead
 		links. Every dropped message is observable; nothing is silently lost.
 	</Card>
 	<Card title="Typed end to end" icon="seti:typescript">
@@ -33,13 +33,13 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 	</Card>
 	<Card title="Vue & React in the box" icon="laptop">
 		A [composable](/frameworks/vue/) and a [hook](/frameworks/react/) as
-		subpath exports with optional peers — reactive connection state,
+		subpath exports with optional peers, reactive connection state,
 		automatic cleanup, one install.
 	</Card>
 	<Card title="Drop-in compatible" icon="approve-check">
 		[`durablews/compat`](/guides/compat/) is a `WebSocket`-shaped class:
 		swap it into existing code or inject it as a library's
-		`webSocketImpl` — with a published known-deviations table.
+		`webSocketImpl`, with a published known-deviations table.
 	</Card>
 	<Card title="Zero dependencies" icon="rocket">
 		Built on the standard global `WebSocket`. No `ws`, no bloat. Browsers,

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -5,7 +5,7 @@ description: Every export of durablews, durablews/vue, and durablews/react.
 
 ## `defineClient(config)`
 
-Creates a new client. Every call returns an independent instance — there is no
+Creates a new client. Every call returns an independent instance, there is no
 shared singleton.
 
 ```ts
@@ -22,24 +22,24 @@ pass generics (`defineClient<Incoming, Outgoing>(config)`), or neither
 
 | Option | Type | Default | |
 | --- | --- | --- | --- |
-| `url` | `string \| URL` | — | required |
-| `protocols` | `string \| string[]` | — | passed to the underlying `WebSocket` |
+| `url` | `string \| URL` |, | required |
+| `protocols` | `string \| string[]` |, | passed to the underlying `WebSocket` |
 | `codec` | `Codec` | `jsonCodec` | [the wire seam](/guides/codecs/) |
 | `reconnect` | `false \| ReconnectOptions` | on | [durability tuning](/guides/durability/#reconnection) |
 | `queue` | `false \| QueueOptions` | on, `maxSize: 256` | [queueing](/guides/durability/#queueing) |
 | `heartbeat` | `HeartbeatOptions` | off | [heartbeat](/guides/durability/#heartbeat) |
-| `schema` | `StandardSchemaV1` | — | [typed messages](/getting-started/#typed-and-validated-messages) |
+| `schema` | `StandardSchemaV1` |, | [typed messages](/getting-started/#typed-and-validated-messages) |
 
 ## The client
 
 | Member | Signature | Notes |
 | --- | --- | --- |
 | `state` | `ConnectionState` | live getter: `idle \| connecting \| open \| closing \| reconnecting \| closed` |
-| `connect()` | `() => Promise<void>` | resolves on first open (incl. a successful retry); idempotent; rejects only on terminal failure — [details](/guides/durability/#connect-under-unlimited-retries) |
+| `connect()` | `() => Promise<void>` | resolves on first open (incl. a successful retry); idempotent; rejects only on terminal failure, [details](/guides/durability/#connect-under-unlimited-retries) |
 | `send(data)` | `(data: TOut) => void` | queues while `connecting`/`reconnecting`; throws in `idle`/`closing`/`closed` |
 | `close(code?, reason?)` | | never triggers reconnection |
 | `on(event, handler)` | returns unsubscribe | typed per event (below) |
-| `use(middleware)` | returns the client | bare function = inbound; `{ inbound?, outbound? }` = per direction — [middleware](/guides/middleware/) |
+| `use(middleware)` | returns the client | bare function = inbound; `{ inbound?, outbound? }` = per direction, [middleware](/guides/middleware/) |
 | `getState()` | `() => ClientState` | frozen `{ state, lastError, retryAttempt, queueLength }`; referentially stable between changes |
 | `subscribe(listener)` | returns unsubscribe | fires on **any** snapshot change |
 
@@ -47,7 +47,7 @@ pass generics (`defineClient<Incoming, Outgoing>(config)`), or neither
 
 | Event | Payload | Fires when |
 | --- | --- | --- |
-| `open` | — | the socket opened (after the queue flushed) |
+| `open` |, | the socket opened (after the queue flushed) |
 | `message` | `TIn` | a message was decoded and (if configured) validated |
 | `close` | `CloseEvent` | the socket closed, clean or not |
 | `error` | `Event \| Error` | transport error, middleware throw, schema failure (`SchemaValidationError`), heartbeat timeout |
@@ -62,7 +62,7 @@ pass generics (`defineClient<Incoming, Outgoing>(config)`), or neither
 | `jsonCodec` | the default codec (JSON with binary passthrough) |
 | `pingpong` | opt-in inbound middleware: auto-replies to `"ping"` with `"pong"`, without emitting `message` |
 | `RECONNECT_DEFAULTS` / `QUEUE_DEFAULTS` | the resolved default option values |
-| `HEARTBEAT_TIMEOUT_CODE` | `4408` — the close code a heartbeat timeout uses (filter it in `shouldReconnect`) |
+| `HEARTBEAT_TIMEOUT_CODE` | `4408`, the close code a heartbeat timeout uses (filter it in `shouldReconnect`) |
 | `SchemaValidationError` | the `error` payload for invalid inbound messages; carries the schema's `issues` |
 
 All public types are exported: `WebSocketClient`, `WebSocketClientConfig`,
@@ -76,8 +76,8 @@ All public types are exported: `WebSocketClient`, `WebSocketClientConfig`,
 
 | Subpath | Export | |
 | --- | --- | --- |
-| `durablews/vue` | `useWebSocket` composable | [Vue guide](/frameworks/vue/) — optional peer `vue >= 3.2` |
-| `durablews/react` | `useWebSocket` hook | [React guide](/frameworks/react/) — optional peer `react >= 18` |
+| `durablews/vue` | `useWebSocket` composable | [Vue guide](/frameworks/vue/), optional peer `vue >= 3.2` |
+| `durablews/react` | `useWebSocket` hook | [React guide](/frameworks/react/), optional peer `react >= 18` |
 
 Installing `durablews` without the frameworks never warns; framework code
 loads only via its subpath.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -1,30 +1,30 @@
-# Chat — Vue and React, one server
+# Chat, Vue and React, one server
 
 The bread-and-butter demo: a broadcast chat with presence and typing
-indicators, implemented twice — once with the Vue composable, once with the
-React hook — against the same server and the same zod schema. Open both side
+indicators, implemented twice, once with the Vue composable, once with the
+React hook, against the same server and the same zod schema. Open both side
 by side and talk to yourself.
 
 ```bash
 pnpm install && pnpm -F durablews build   # once, from the repo root
 
-pnpm -F example-chat dev:server   # terminal 1 — ws://localhost:8789
-pnpm -F example-chat dev:vue      # terminal 2 — http://localhost:5174
-pnpm -F example-chat dev:react    # terminal 3 — http://localhost:5175
+pnpm -F example-chat dev:server   # terminal 1, ws://localhost:8789
+pnpm -F example-chat dev:vue      # terminal 2, http://localhost:5174
+pnpm -F example-chat dev:react    # terminal 3, http://localhost:5175
 ```
 
 What it shows:
 
-- **`useWebSocket` in both idioms** — config-owned client, auto-connect,
+- **`useWebSocket` in both idioms**: config-owned client, auto-connect,
   cleanup on unmount, reactive `state`.
 - **One zod schema, both clients** ([shared/schema.ts](shared/schema.ts)):
   message types are *inferred* and every inbound frame is runtime-validated
   before a handler sees it.
-- **History is app state** — `lastMessage` holds only the latest; each client
+- **History is app state**: `lastMessage` holds only the latest; each client
   accumulates its own list via `client.on("message", …)`, the boundary
   DurableWS deliberately doesn't cross.
 - **Typing indicators as a call-site policy** (throttle in front of `send()`),
   per the middleware guide's layering rule.
 - **Durability for free**: kill the server mid-conversation (`Ctrl-C`,
-  restart it) — both clients walk through `reconnecting` and resume; anything
+  restart it), both clients walk through `reconnecting` and resume; anything
   sent while down queues and flushes.

--- a/examples/collab-notepad/README.md
+++ b/examples/collab-notepad/README.md
@@ -1,4 +1,4 @@
-# Collab notepad — the one-line migration
+# Collab notepad, the one-line migration
 
 A collaborative notepad written against the **standard `WebSocket` API**, made
 durable by swapping a single import:
@@ -14,19 +14,19 @@ pnpm -F example-collab-notepad dev        # server + Vite (one command)
 
 Open the printed URL **twice**, side by side. Type in one window, watch the
 other. Then the durability demo: **kill the server (`Ctrl-C`), keep typing,
-restart it** — both windows walk through `reconnecting`, your buffered update
+restart it**: both windows walk through `reconnecting`, your buffered update
 flushes, and the documents converge. With the native `WebSocket`, the same app
 is dead at the first blip.
 
-The sync itself is deliberately demo-grade (last-write-wins full-text) — the
+The sync itself is deliberately demo-grade (last-write-wins full-text), the
 point is the transport, not CRDTs.
 
 ## Why not y-websocket/Yjs injection?
 
-We tried — and it taught us the layering rule now documented in the
+We tried, and it taught us the layering rule now documented in the
 [compat guide](https://durablews.imns.co/guides/compat/): libraries with
 **stateful sync protocols** (y-websocket, graphql-ws) implement their *own*
 reconnection because they must re-handshake per connection. Injecting a
 self-reconnecting socket under them creates two reconnect layers fighting
 each other. Compat's sweet spot is code that treats the socket as a plain
-pipe — like this app, and like most hand-rolled WebSocket code.
+pipe, like this app, and like most hand-rolled WebSocket code.

--- a/examples/resilience-playground/README.md
+++ b/examples/resilience-playground/README.md
@@ -1,7 +1,7 @@
 # Resilience playground
 
 The flagship DurableWS demo: a server you can sabotage from the client, and a
-connection that survives it. Drop it, mute it, flood it while it's down —
+connection that survives it. Drop it, mute it, flood it while it's down,
 then watch the state machine, retry counter, and queue recover.
 
 ```bash
@@ -11,14 +11,14 @@ pnpm -F example-resilience-playground dev # server + Vite (one command)
 
 Open the printed Vite URL. Things to try:
 
-- **💣 Drop** — the server closes you with code 1012. The badge walks
+- **💣 Drop**: the server closes you with code 1012. The badge walks
   `open → reconnecting → connecting → open`; the retry counter resets on
   success.
-- **🔇 Mute** — the server stays connected but goes silent. The heartbeat
+- **🔇 Mute**: the server stays connected but goes silent. The heartbeat
   (2s interval here) declares the link dead, closes with code `4408`, and the
   normal reconnect machinery gets you a fresh, unmuted connection.
-- **📬 Burst while down** — hit Drop, then immediately Burst. The messages
+- **📬 Burst while down**: hit Drop, then immediately Burst. The messages
   queue (watch the gauge), then flush in order the moment the socket reopens.
-- **Close, then Burst** — a deliberate close drops the queue *observably*:
+- **Close, then Burst**: a deliberate close drops the queue *observably*:
   every message surfaces in the log as a `drop` event. Nothing is silently
   lost, ever.

--- a/packages/durablews/CHANGELOG.md
+++ b/packages/durablews/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- 6acd50b: README: drop the alpha banner and `@alpha` install instructions — 2.0.0 is the latest release. No code changes; this publish exists so the npm page stops showing alpha framing.
+- 6acd50b: README: drop the alpha banner and `@alpha` install instructions, 2.0.0 is the latest release. No code changes; this publish exists so the npm page stops showing alpha framing.
 
 ## 2.0.0
 
 ### Minor Changes
 
-- dd4dfbd: durablews 2.0.0 — stable.
+- dd4dfbd: durablews 2.0.0, stable.
 
   Everything from the alpha line, graduated: automatic reconnection
   (full-jitter exponential backoff, `shouldReconnect` veto), bounded message
@@ -18,32 +18,32 @@
   typed + Standard-Schema-validated messages, middleware in both directions
   (transmission-time, ordered async), a pluggable codec, Vue and React
   bindings (`durablews/vue`, `durablews/react`), and a drop-in `WebSocket`
-  class (`durablews/compat`) — zero runtime dependencies, core ≤ 3 KB brotli
+  class (`durablews/compat`), zero runtime dependencies, core ≤ 3 KB brotli
   (CI-enforced), tested in browsers (Playwright), Node 22, Deno 2, and Bun.
 
   Docs: https://durablews.imns.co
 
 - d68f047: First public v2 alpha. A ground-up rewrite of the client around an explicit
-  connection state machine — durable by default, zero dependencies, built on the
+  connection state machine, durable by default, zero dependencies, built on the
   standard global `WebSocket` (browsers, Node ≥ 22, Deno, Bun, edge).
 
-  - **Automatic reconnection, on by default** — full-jitter exponential backoff,
+  - **Automatic reconnection, on by default**: full-jitter exponential backoff,
     unlimited retries, `shouldReconnect` veto, `reconnecting` events.
-  - **Message queueing while disconnected, on by default** — bounded,
+  - **Message queueing while disconnected, on by default**: bounded,
     drop-oldest, flushed in order on open; every dropped message fires a `drop`
     event.
-  - **Opt-in heartbeat / idle detection** — dead links are closed (code `4408`)
+  - **Opt-in heartbeat / idle detection**: dead links are closed (code `4408`)
     and recovered through the normal reconnect machinery.
-  - **Typed + validated messages** — pass any Standard Schema (zod, valibot,
+  - **Typed + validated messages**: pass any Standard Schema (zod, valibot,
     arktype, …) and message types are inferred and runtime-validated; or use
     plain generics.
-  - **Middleware, inbound and outbound** — `use()` onion pipeline; outbound runs
+  - **Middleware, inbound and outbound**: `use()` onion pipeline; outbound runs
     at transmission time, async-capable with strict send-order preservation
     (auth/token-refresh ready).
-  - **Framework bindings in the box** — `durablews/vue` (composable) and
+  - **Framework bindings in the box**: `durablews/vue` (composable) and
     `durablews/react` (hook via `useSyncExternalStore`), with the frameworks as
     optional peers.
-  - **Pluggable codec** — JSON by default, swap in anything.
+  - **Pluggable codec**: JSON by default, swap in anything.
   - Promise-based `connect()`, standard event vocabulary (`open` / `message` /
     `close` / `error` / `statechange`), observable state snapshots with
     `subscribe()` / `getState()`.
@@ -56,26 +56,26 @@
 ### Minor Changes
 
 - d68f047: First public v2 alpha. A ground-up rewrite of the client around an explicit
-  connection state machine — durable by default, zero dependencies, built on the
+  connection state machine, durable by default, zero dependencies, built on the
   standard global `WebSocket` (browsers, Node ≥ 22, Deno, Bun, edge).
 
-  - **Automatic reconnection, on by default** — full-jitter exponential backoff,
+  - **Automatic reconnection, on by default**: full-jitter exponential backoff,
     unlimited retries, `shouldReconnect` veto, `reconnecting` events.
-  - **Message queueing while disconnected, on by default** — bounded,
+  - **Message queueing while disconnected, on by default**: bounded,
     drop-oldest, flushed in order on open; every dropped message fires a `drop`
     event.
-  - **Opt-in heartbeat / idle detection** — dead links are closed (code `4408`)
+  - **Opt-in heartbeat / idle detection**: dead links are closed (code `4408`)
     and recovered through the normal reconnect machinery.
-  - **Typed + validated messages** — pass any Standard Schema (zod, valibot,
+  - **Typed + validated messages**: pass any Standard Schema (zod, valibot,
     arktype, …) and message types are inferred and runtime-validated; or use
     plain generics.
-  - **Middleware, inbound and outbound** — `use()` onion pipeline; outbound runs
+  - **Middleware, inbound and outbound**: `use()` onion pipeline; outbound runs
     at transmission time, async-capable with strict send-order preservation
     (auth/token-refresh ready).
-  - **Framework bindings in the box** — `durablews/vue` (composable) and
+  - **Framework bindings in the box**: `durablews/vue` (composable) and
     `durablews/react` (hook via `useSyncExternalStore`), with the frameworks as
     optional peers.
-  - **Pluggable codec** — JSON by default, swap in anything.
+  - **Pluggable codec**: JSON by default, swap in anything.
   - Promise-based `connect()`, standard event vocabulary (`open` / `message` /
     `close` / `error` / `statechange`), observable state snapshots with
     `subscribe()` / `getState()`.

--- a/packages/durablews/README.md
+++ b/packages/durablews/README.md
@@ -1,40 +1,40 @@
 # DurableWS
 
-> The WebSocket client that survives the real world — automatic reconnection,
+> The WebSocket client that survives the real world, automatic reconnection,
 > bounded queueing, and typed messages. Zero dependencies, every modern
 > runtime, durable by default.
 
 > The features below are built and tested (unit, integration, real-browser
 > e2e). The
 > [architecture RFC](https://github.com/imnsco/DurableWS/blob/main/rfcs/0001-v2-architecture.md)
-> tracks design and status. The `1.x` line predates the v2 rewrite — don't
+> tracks design and status. The `1.x` line predates the v2 rewrite, don't
 > use it.
 
 ## What you get
 
-- **Automatic reconnection, on by default** — full-jitter exponential
+- **Automatic reconnection, on by default**: full-jitter exponential
   backoff, unlimited retries, a `shouldReconnect` veto, and `reconnecting`
   events for your UI.
-- **Message queueing while disconnected, on by default** — bounded,
+- **Message queueing while disconnected, on by default**: bounded,
   drop-oldest, flushed in order on open. Every dropped message fires a `drop`
   event; nothing is silently lost.
-- **Opt-in heartbeat / idle detection** — quietly-dead links are closed (code
+- **Opt-in heartbeat / idle detection**: quietly-dead links are closed (code
   `4408`) and recovered through the normal reconnect machinery.
-- **Typed + validated messages** — pass any
+- **Typed + validated messages**: pass any
   [Standard Schema](https://standardschema.dev) (zod, valibot, arktype, …)
   and inbound messages are type-inferred *and* runtime-validated.
-- **Middleware, inbound and outbound** — an onion pipeline with async-safe,
+- **Middleware, inbound and outbound**: an onion pipeline with async-safe,
   ordered outbound execution (auth/token-refresh ready).
-- **Pluggable codec** — JSON by default; swap in msgpack or anything else.
-- **Vue & React bindings in the box** — `durablews/vue` (composable) and
+- **Pluggable codec**: JSON by default; swap in msgpack or anything else.
+- **Vue & React bindings in the box**: `durablews/vue` (composable) and
   `durablews/react` (hook); the frameworks are optional peers.
-- **A drop-in `WebSocket` class** — `durablews/compat` for one-line migration
+- **A drop-in `WebSocket` class**: `durablews/compat` for one-line migration
   or `webSocketImpl` injection, with a published known-deviations table.
 - **Zero runtime dependencies**, built on the standard global `WebSocket`.
 
 ## Requirements
 
-- **Node.js ≥ 22** — the first release where the global `WebSocket` is
+- **Node.js ≥ 22**: the first release where the global `WebSocket` is
   available unflagged. (There is no `ws` dependency, by design.)
 - Any modern runtime with a global `WebSocket`: current browsers, Deno, Bun,
   and Cloudflare Workers.
@@ -72,19 +72,19 @@ const Message = z.object({ type: z.string(), body: z.string() });
 const client = defineClient({ url, schema: Message });
 
 client.on("message", (msg) => {
-    // msg: { type: string; body: string } — validated at runtime
+    // msg: { type: string; body: string }, validated at runtime
 });
 ```
 
 ## Documentation
 
-**[durablews.imns.co](https://durablews.imns.co)** — getting started, guides
+**[durablews.imns.co](https://durablews.imns.co)**: getting started, guides
 (durability tuning, middleware, codecs, drop-in compat), framework pages, the
 API reference, and an honest comparison with the alternatives.
 
 ## Contributing
 
-Contributions are welcome — see [CONTRIBUTING](https://github.com/imnsco/DurableWS/blob/main/CONTRIBUTING.md).
+Contributions are welcome, see [CONTRIBUTING](https://github.com/imnsco/DurableWS/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/rfcs/0001-v2-architecture.md
+++ b/rfcs/0001-v2-architecture.md
@@ -1,4 +1,4 @@
-# RFC 0001 — DurableWS v2 Architecture
+# RFC 0001, DurableWS v2 Architecture
 
 - **Status:** Implemented (shipped as `durablews@2.0.0`, 2026-06-10)
 - **Author:** Nate Smith
@@ -6,9 +6,9 @@
 - **Supersedes:** the v1.x design (published as `durablews@1.0.1`)
 
 > **This RFC is frozen.** It is the record of the v2 design and its
-> implementation (milestones M1–M4). Ongoing planning lives in
+> implementation (milestones M1-M4). Ongoing planning lives in
 > [ROADMAP.md](../ROADMAP.md); future architecture-level changes get a new
-> RFC — see [rfcs/README.md](README.md) for the process.
+> RFC, see [rfcs/README.md](README.md) for the process.
 
 ---
 
@@ -29,11 +29,11 @@ and release pipeline a serious OSS project needs.
 
 The v1 README and npm keywords promise durability the code does not deliver:
 
-- **Automatic reconnection / exponential backoff** — not implemented. Nothing
+- **Automatic reconnection / exponential backoff**: not implemented. Nothing
   ever transitions to `RECONNECTING`.
-- **Idle detection** — not implemented.
-- **Message queueing** — not implemented; `send()` drops messages when closed.
-- **Authentication** — not implemented.
+- **Idle detection**: not implemented.
+- **Message queueing**: not implemented; `send()` drops messages when closed.
+- **Authentication**: not implemented.
 
 There is also a latent correctness bug: the close handler is registered under
 the event name `"closed"` while the client dispatches `"close"`, so the
@@ -56,22 +56,22 @@ but technically wrong for a client-only library: socket.io's gravity is
 WS servers, and its users cannot migrate to us. socket.io defines the *category
 expectations*, not the actual contest.
 
-The real incumbents in our niche — durable clients over the standard
-`WebSocket` — are:
+The real incumbents in our niche, durable clients over the standard
+`WebSocket`, are:
 
-- **`reconnecting-websocket`** — the long-standing default for "WebSocket that
+- **`reconnecting-websocket`**: the long-standing default for "WebSocket that
   reconnects" (hundreds of thousands of weekly downloads) and effectively
   **abandoned**. This is the market being taken.
-- **`partysocket`** — the maintained fork (PartyKit/Cloudflare), actively
+- **`partysocket`**: the maintained fork (PartyKit/Cloudflare), actively
   growing. This is the rival evaluators will compare us against.
 
 Differentiation vs. both: typed events, the codec seam, middleware, **bounded
 and observable queueing**, a promise-based `connect()`, and an observable FSM.
 *(Correction, M4 slice 4: an earlier revision claimed "partysocket does not
-queue" — false. Both incumbents buffer while disconnected, unbounded by
+queue", false. Both incumbents buffer while disconnected, unbounded by
 default with a silent `maxEnqueuedMessages` cap. The honest differentiator is
 the queue's edges: bounded by default, drop-oldest, and every drop observable
-via `drop` events — never a silent buffer.)* This story must be explicit — a
+via `drop` events, never a silent buffer.)* This story must be explicit, a
 comparison page is among the highest-leverage docs we can ship (M4).
 
 Both incumbents win adoption via a **drop-in `WebSocket`-compatible class**
@@ -81,9 +81,9 @@ wrapping core in the standard `WebSocket` shape could capture it without
 compromising the primary API (decision tracked in §9).
 
 **Popularity has mechanics, and they are scheduled work, not afterthoughts**
-(all M4): framework bindings (React first — a copy-pasteable hook is worth more
+(all M4): framework bindings (React first, a copy-pasteable hook is worth more
 adoption than any single core feature), typed messages as the DX showcase,
-bundle-size as a marketed asset (zero-dep, few KB — size badge in CI),
+bundle-size as a marketed asset (zero-dep, few KB, size badge in CI),
 comparison pages, `llms.txt` on the docs site (AI assistants are a top
 discovery channel), runnable `examples/`, and a launch post ("we fixed
 reconnection properly: full jitter, bounded queues, an FSM").
@@ -109,7 +109,7 @@ reconnection properly: full jitter, bounded queues, an FSM").
   of scope for v2.
 - **No general-purpose application-state manager.** Core owns only connection
   state. App state is the app's job; we win by making delivery into the user's
-  own state tool effortless. Core stays zero-dep — we neither ship nor depend on
+  own state tool effortless. Core stays zero-dep, we neither ship nor depend on
   a state library.
 - **No `ws` dependency / injection.** Target modern runtimes that expose a
   standard global `WebSocket`.
@@ -129,17 +129,17 @@ reconnection properly: full jitter, bounded queues, an FSM").
    connection lifecycle  ──►  typed Finite State Machine (the only core state)
 ```
 
-> **Status note:** both directions are built — the **inbound** pipeline
+> **Status note:** both directions are built, the **inbound** pipeline
 > shipped in M2, the **outbound** pipeline in M4 slice 3 (object form of
 > `use()`; semantics in §9). Heartbeat pings deliberately bypass the outbound
 > pipeline.
 
 Four distinct seams, deliberately kept separate:
 
-1. **Connection FSM** — owns lifecycle state and transitions.
-2. **Codec** — the wire format (`encode`/`decode`).
-3. **Middleware** — cross-cutting behavior over the message pipeline.
-4. **Events** — how the user receives messages and lifecycle notifications.
+1. **Connection FSM**: owns lifecycle state and transitions.
+2. **Codec**: the wire format (`encode`/`decode`).
+3. **Middleware**: cross-cutting behavior over the message pipeline.
+4. **Events**: how the user receives messages and lifecycle notifications.
 
 ### 4.2 Connection state: a typed finite state machine
 
@@ -157,13 +157,13 @@ idle ──connect()──► connecting ──open──► open
 ```
 
 States (lowercase, matching the web platform's vocabulary): `idle`,
-`connecting`, `open`, `closing`, `closed` — plus `reconnecting` in M3.
+`connecting`, `open`, `closing`, `closed`, plus `reconnecting` in M3.
 
 Transitions are **guarded by a transition table** (`fsm.ts`): an illegal
 `(state, event)` pair is the *absence of a table entry* and is rejected
 explicitly rather than silently doing nothing. This makes the v1
 `close`/`closed` class of bug impossible by construction. Transport errors are
-deliberately *not* FSM events — an `error` does not itself change connection
+deliberately *not* FSM events, an `error` does not itself change connection
 state (the subsequent `close` performs the transition); errors are recorded
 (`lastError`) and emitted out-of-band.
 
@@ -178,10 +178,10 @@ client.on("statechange", ({ previous, current }) => { /* ... */ });
 `retryAttempt` and `queueLength` join the snapshot as M3's features land. The
 `on("statechange")` + `getState()` pair is the `subscribe`/`getSnapshot` shape
 a React `useSyncExternalStore` adapter needs (bindings are scheduled M4 work,
-not an afterthought — see §2.1). This is the **only** state core owns. It never
+not an afterthought, see §2.1). This is the **only** state core owns. It never
 grows unbounded.
 
-### 4.3 Codec — the wire seam
+### 4.3 Codec, the wire seam
 
 Every message crosses encode/decode, so it is a first-class option, not
 middleware:
@@ -200,7 +200,7 @@ codecs (`durablews/msgpack`, the socket.io framing) are swapped in via config:
 const client = defineClient({ url, codec: msgpackCodec });
 ```
 
-### 4.4 Middleware — the extension crown jewel
+### 4.4 Middleware, the extension crown jewel
 
 The middleware pipeline (the Hono `app.use` analog) is retained and elevated. It
 runs over the message pipeline in both directions (inbound and outbound) for
@@ -210,7 +210,7 @@ Middleware **intercepts**; it does not add public API.
 The existing event-bus and pipeline implementation survive largely intact. The
 generic action/dispatch/reducer surface is removed as a public concept.
 
-### 4.5 Events — how messages are delivered
+### 4.5 Events, how messages are delivered
 
 Messages flow `onmessage → codec.decode → inbound middleware → emit`. Handlers
 receive a message and forget it; nothing is retained in state. Typed:
@@ -219,17 +219,17 @@ receive a message and forget it; nothing is retained in state. Typed:
 const off = client.on<ChatMessage>("message", (msg) => { /* ... */ });
 ```
 
-### 4.6 Extension vocabulary — one word per seam
+### 4.6 Extension vocabulary, one word per seam
 
 Every extension concept is **named by the seam it occupies**, and that word is
 used consistently across code, docs, and this RFC:
 
 | Term | What it is | Registered via | Adds client API? |
 | --- | --- | --- | --- |
-| **Middleware** | Intercepts messages on the pipeline — inbound and/or outbound, same word for both directions | `client.use(...)` | Never |
+| **Middleware** | Intercepts messages on the pipeline, inbound and/or outbound, same word for both directions | `client.use(...)` | Never |
 | **Codec** | Translates the wire format | `codec` config option | Never |
-| **Plugin** | Adds new client capability (channels, presence) | TBD (M4+) | Yes — the only one |
-| **Binding** | Adapts the client to a framework's reactivity | subpath import (`durablews/vue`, `durablews/react`) | n/a — framework surface, not client surface |
+| **Plugin** | Adds new client capability (channels, presence) | TBD (M4+) | Yes, the only one |
+| **Binding** | Adapts the client to a framework's reactivity | subpath import (`durablews/vue`, `durablews/react`) | n/a, framework surface, not client surface |
 
 **Plugins** are the one category that adds *new client methods* (e.g.
 `client.channel("room")`, presence). (If channels turn out to be the only such
@@ -237,20 +237,20 @@ case we may simply call it "the channels API"; the plugin concept exists for
 when third parties need the same capability.)
 
 **Bindings** are the neutral, cross-framework word (used in this RFC and in
-comparison contexts); each framework's docs speak its community's tongue — a
+comparison contexts); each framework's docs speak its community's tongue, a
 Vue *composable*, a React *hook* (settled M4 decision). Those words name the
 *form* the binding takes in that framework, not a separate concept.
 
 The word "packs" is explicitly rejected.
 
-### 4.7 Primary API (sketch — subject to refinement during M1)
+### 4.7 Primary API (sketch, subject to refinement during M1)
 
 ```ts
 import { defineClient } from "durablews";
 
 const client = defineClient({
   url: "wss://example.com/socket",
-  // durable by default — these are ON unless disabled:
+  // durable by default, these are ON unless disabled:
   // reconnect: { backoff: "exponential", maxRetries: Infinity },
   // queue: true,
   // idle: { timeout: 30_000 },
@@ -276,7 +276,7 @@ call) is removed. Apps that want a singleton export their own instance.
 
 - **pnpm monorepo**, but **one published package** (`durablews`). Optional
   add-ons ship as **subpath exports** (`durablews/socketio`, `durablews/msgpack`,
-  `durablews/auth`) and are tree-shakeable — **including framework bindings**
+  `durablews/auth`) and are tree-shakeable, **including framework bindings**
   (`durablews/vue`, `durablews/react`), whose framework peers are *optional*
   peerDependencies (see M4 decisions, §8). Install stays `npm i durablews`. A
   separate package is introduced later only if something truly should not be
@@ -301,8 +301,8 @@ durablews/                 (repo root, pnpm workspace)
 published docs site, for now). RFC 0001 currently doubles as the live
 implementation tracker (§8), which is a contributor artifact rather than
 polished public content, so the Starlight site ships user-facing docs only in
-M1. Publishing RFCs to the site — e.g. as a dedicated Astro content collection
-with its own schema, Vue-RFC-style — is revisited in M4 once the API and this
+M1. Publishing RFCs to the site, e.g. as a dedicated Astro content collection
+with its own schema, Vue-RFC-style, is revisited in M4 once the API and this
 document's role have stabilized.
 
 ### Third-party plugin naming convention
@@ -312,22 +312,22 @@ CONTRIBUTING), e.g. `durablews-plugin-<name>`, so the ecosystem is consistent
 and discoverable. Officially-shipped add-ons live inside the one package under
 subpath exports.
 
-## 6. Testing — first-class test pyramid
+## 6. Testing, first-class test pyramid
 
 The pyramid is established in **M1**, not deferred:
 
-- **Unit (base):** pure logic — FSM transitions, backoff math, queue behavior,
+- **Unit (base):** pure logic, FSM transitions, backoff math, queue behavior,
   codec encode/decode. No sockets. (vitest)
 - **Integration (middle):** the client driven against a mock WS server
-  (`vitest-websocket-mock`) — full lifecycle, reconnection flush, idle
+  (`vitest-websocket-mock`), full lifecycle, reconnection flush, idle
   detection, middleware ordering.
 - **Cross-runtime e2e (top, load-bearing):** the client against a *real*
-  WebSocket server, executed in *real* runtimes — Node, a browser via
+  WebSocket server, executed in *real* runtimes, Node, a browser via
   Playwright, and at least one of Deno/Bun. This tier verifies the multi-runtime
   claim; an untested claim is a false claim.
   **Status (post-M2): browser ✅ (Playwright Chromium, required CI check);
   Node-as-client ⬜; Deno/Bun ⬜.** By this section's own standard, the
-  multi-runtime claim is only one-third verified — the remaining runtimes are
+  multi-runtime claim is only one-third verified, the remaining runtimes are
   scheduled M4 scope (§8).
 
 Tests must assert **state correctness**, not merely that events fired (the gap
@@ -336,25 +336,25 @@ that hid the v1 close bug).
 ## 7. Tooling, CI & deployment
 
 - **Package manager:** pnpm (workspaces).
-- **Lint + format:** **Biome** — replaces ESLint + Prettier + their plugins with
+- **Lint + format:** **Biome**: replaces ESLint + Prettier + their plugins with
   one fast tool. Known trade-off: Biome lints the AST and does not yet do
   *type-aware* rules; acceptable for a small zero-dep lib under `strict` `tsc`,
   which covers the type-level checks.
-- **Build:** **tsup** (esbuild) — purpose-built for libraries; emits dual
+- **Build:** **tsup** (esbuild), purpose-built for libraries; emits dual
   ESM/CJS + `.d.ts` with minimal config. Replaces the v1 Vite library-mode +
   `vite-plugin-dts` setup (Vite is kept only for the docs/app side via Astro).
 - **Test:** **Vitest** (unit + integration) and **Playwright** (browser e2e);
   Deno/Bun runners for their respective cross-runtime e2e.
-- **Versioning & release:** **changesets** — versioning, generated CHANGELOG,
+- **Versioning & release:** **changesets**: versioning, generated CHANGELOG,
   and automated npm publish.
-- **Publish validation (in CI):** **publint** + **@arethetypeswrong/cli** —
+- **Publish validation (in CI):** **publint** + **@arethetypeswrong/cli**,
   verify `exports`/types resolve correctly across ESM/CJS/bundlers.
-- **Git hooks:** **lefthook** — fast pre-commit lint/format on staged files.
-- **Dead-code/dep hygiene:** **knip** (optional, nice-to-have) — flags unused
+- **Git hooks:** **lefthook**: fast pre-commit lint/format on staged files.
+- **Dead-code/dep hygiene:** **knip** (optional, nice-to-have), flags unused
   files, exports, and dependencies.
-- **Docs site:** Astro **5** + Starlight (not Astro 6 — out but still buggy).
+- **Docs site:** Astro **5** + Starlight (not Astro 6, out but still buggy).
   In-repo, docs-as-code. Chosen over Mintlify (SaaS/vendor lock-in, cost).
-- **Docs deploy:** Cloudflare **Workers** (not Pages — different adapter,
+- **Docs deploy:** Cloudflare **Workers** (not Pages, different adapter,
   static-assets model, and `wrangler` deploy), via CI on merge to `main`.
   First-class, not an afterthought.
 - **CI:** runs on PRs (not just push), and must typecheck + Biome lint + build +
@@ -364,7 +364,7 @@ that hid the v1 close bug).
   TS 6.0-nightly editor flagged a real type hole (`Codec.encode` returning
   `SharedArrayBuffer`-compatible types that `WebSocket.send` rejects under
   6.0's stricter `lib.dom.d.ts`) that stable `tsc` cannot see. Gating merges on
-  a nightly compiler is a footgun, so the job is advisory — it makes
+  a nightly compiler is a footgun, so the job is advisory, it makes
   next-TypeScript breakage visible without blocking. (The code fix itself lands
   via PR #18's thread.)
 - **Release:** changesets-driven automated publish of the lib to npm (the only
@@ -375,33 +375,33 @@ that hid the v1 close bug).
 ## 8. Implementation plan & status
 
 OSS hygiene, tooling, CI, and docs *infrastructure* are **foundational, not a
-trailing phase** — they land up front and are treated as first-class. Only API
+trailing phase**: they land up front and are treated as first-class. Only API
 *documentation content* trails, because it requires a stable API.
 
-This section is the **live execution tracker** — the project uses doc-based
+This section is the **live execution tracker**: the project uses doc-based
 tracking (no GitHub issue board), so this is kept current as work lands.
 Status: ✅ done · 🚧 in progress · ⬜ not started.
 
-### M1 — Repo foundation ✅
+### M1: Repo foundation ✅
 
-Structural only — no behavior change to the library.
+Structural only, no behavior change to the library.
 
-- ✅ **Slice 1 — Monorepo scaffold + core tooling.** pnpm workspace; library
+- ✅ **Slice 1: Monorepo scaffold + core tooling.** pnpm workspace; library
   moved to `packages/durablews`; Vite library-mode → tsup (ESM + CJS + dual
   `.d.ts`); ESLint + Prettier → Biome; package set to `2.0.0-alpha.0`.
   (commit `fe6faae`)
-- ✅ **Slice 2 — CI, release & publish tooling.** CI on PRs + pushes (Node
+- ✅ **Slice 2: CI, release & publish tooling.** CI on PRs + pushes (Node
   22/24 matrix; Biome, typecheck, build, test, publint + attw); changesets
   (access: public); lefthook pre-commit; `engines` corrected to Node ≥22;
   `tsconfig` `baseUrl` anti-pattern removed. (commits `5b1c7c9`, `0fbd214`,
   `a4d4b2a`)
-- ✅ **Slice 3 — OSS hygiene.** Corrected package README (durability features
+- ✅ **Slice 3: OSS hygiene.** Corrected package README (durability features
   framed as roadmap; Node ≥22 stated) + root README; CONTRIBUTING (incl. the
   `durablews-plugin-*` naming convention and changesets workflow); SECURITY;
   Contributor Covenant CODE_OF_CONDUCT; issue forms + PR template.
   (commit `12012c1`)
-- ✅ **Slice 4 — Docs site.** Astro 5 + Starlight site in `docs/` (user-facing
-  content only — landing + getting-started); RFCs kept as repo-internal
+- ✅ **Slice 4: Docs site.** Astro 5 + Starlight site in `docs/` (user-facing
+  content only, landing + getting-started); RFCs kept as repo-internal
   `rfcs/` markdown (site publishing of RFCs deferred to M4). Built for
   Cloudflare Workers via the `@astrojs/cloudflare` adapter (emits a Worker +
   asset bundle, configured in `wrangler.jsonc`), domain `durablews.imns.co`;
@@ -409,7 +409,7 @@ Structural only — no behavior change to the library.
   variable until CF secrets + DNS are set. Added a required `Docs` CI job.
   (commit `ce286df`)
 
-### M2 — Core rewrite & correctness ✅
+### M2: Core rewrite & correctness ✅
 
 Typed connection FSM; codec seam; middleware pipeline retained; event delivery;
 drop singleton caching; remove messages-in-state; fix the close/error bug; strip
@@ -419,7 +419,7 @@ console noise. Full test pyramid populated for the core. Everything green.
 
 - **The generic store is removed**, not retained. `defineStore` / `dispatch` /
   `defineAction` / `composeActions` / `HandlerFn` are deleted. A free-form
-  reducer is the wrong tool for a connection lifecycle — it has no concept of an
+  reducer is the wrong tool for a connection lifecycle, it has no concept of an
   illegal transition, which is precisely what allowed `dispatch("close")` to be
   a silent no-op (the close/error bug). State is *not* removed: it is replaced
   by (a) a typed FSM that forbids illegal transitions by construction and (b) a
@@ -431,12 +431,12 @@ console noise. Full test pyramid populated for the core. Everything green.
   `open`.) We are pre-redesign and break freely.
 - **`connect()` contract** (the stable-across-M2→M3 subset):
   - Resolves the first time the socket opens. *(Never changes.)*
-  - Idempotent — concurrent/repeat calls return the same in-flight promise;
+  - Idempotent, concurrent/repeat calls return the same in-flight promise;
     calling while already open resolves immediately.
   - Rejection means **terminal** failure, not first failure. In M2 (no
     reconnect) a failed initial connection is terminal, so it rejects. In M3,
     reconnect redefines "terminal" as *retries exhausted*, so `connect()` stays
-    pending across retries and rejects only when the library gives up — the
+    pending across retries and rejects only when the library gives up, the
     meaning holds, only the definition of "terminal" tightens, so no API churn.
   - Ongoing failures after first open surface via `on("error")` / `on("close")`,
     not the promise. Docs note: `await` or `.catch` to avoid an unhandled
@@ -445,7 +445,7 @@ console noise. Full test pyramid populated for the core. Everything green.
 **Slices** (each a green, independently reviewable PR; unit + integration tests
 travel in-PR):
 
-- ✅ **Slice 1 — FSM lifecycle core.** Typed connection FSM (`fsm.ts` —
+- ✅ **Slice 1: FSM lifecycle core.** Typed connection FSM (`fsm.ts`,
   transition table over idle/connecting/open/closing/closed) replacing the
   store's lifecycle role; illegal `(state, event)` pairs are rejected, killing
   the close/error dead-transition bug. Standard `WebSocket` event vocabulary
@@ -454,20 +454,20 @@ travel in-PR):
   console noise removed; `send()` throws when not open. Store, action handlers,
   and pingpong/logger middleware deleted (pipeline returns in slice 3).
   (commit `5c26af7`)
-- ✅ **Slice 2 — Codec seam.** Pluggable `encode` / `decode` with a default JSON
+- ✅ **Slice 2: Codec seam.** Pluggable `encode` / `decode` with a default JSON
   codec (`codec.ts` / `jsonCodec`); `config.codec` option. Replaced the inline
   JSON; folded `safeJSONParse` into the default codec; deleted the broken,
   unused `normalizeURL` (and the now-empty `utils.ts`). `Codec` + `jsonCodec`
   exported. (commit `aa71812`)
-- ✅ **Slice 3 — Middleware pipeline (re-homed).** Standalone onion-model
+- ✅ **Slice 3: Middleware pipeline (re-homed).** Standalone onion-model
   pipeline (`pipeline.ts`) on the decoded-message path; `client.use()` returns
   the client for chaining; short-circuit when a middleware skips `next()`;
   middleware errors surface as `error` (payload widened to `Event | Error`).
   `pingpong` is opt-in (`middleware.ts`); the default `logger` is gone.
   (commit `5a47c0c`)
-- ✅ **Slice 4 — Test pyramid + e2e.** Filled integration gaps (unsubscribe,
+- ✅ **Slice 4: Test pyramid + e2e.** Filled integration gaps (unsubscribe,
   frozen `getState()` snapshot, full `statechange` sequence, `connect()` while
-  closing). Added a Playwright browser e2e harness — real Chromium + real
+  closing). Added a Playwright browser e2e harness, real Chromium + real
   `WebSocket` against a local `ws` echo server, driving the built ESM bundle
   (connect/round-trip/close + reconnect). New `E2E` CI job, added to the branch
   ruleset's required checks. (commit `b35c511`)
@@ -475,7 +475,7 @@ travel in-PR):
 Order is deliberate: the codec defines what "decoded" means, so it precedes the
 middleware that operates on decoded messages.
 
-### M3 — Durability ✅
+### M3: Durability ✅
 
 Reconnection + exponential backoff, message queueing, idle detection. Each lands
 as its own slice with unit + integration + e2e coverage.
@@ -494,24 +494,24 @@ as its own slice with unit + integration + e2e coverage.
 - **Message queueing.** On by default. `send()` while not-open **queues**
   instead of throwing (the planned evolution of M2's throw) and flushes in order
   on (re)open. **Bounded** (`maxSize`, proposed default ~256) with
-  **drop-oldest** + a `drop` event when full — never silently unbounded, never
+  **drop-oldest** + a `drop` event when full, never silently unbounded, never
   silently lossy. `send()` while `idle`/terminally-`closed` still throws. Config:
   `queue?: false | { maxSize? }`.
 - **Idle detection is opt-in, not on by default** (overrides the original
   "on by default" note). A naive "no inbound traffic → reconnect" harms
   legitimately-quiet-but-healthy connections, and any heartbeat depends on
   app-level ping semantics the library can't assume. Ship it as
-  `heartbeat?: { interval, message?, timeout }` — when set, ping every
+  `heartbeat?: { interval, message?, timeout }`, when set, ping every
   `interval` and force a reconnect if nothing arrives within `timeout`; off
   otherwise.
 
 **Slices** (each a green, independently reviewable PR). Unlike M2, the e2e
 harness already exists, so each slice carries its own unit + integration + e2e
-coverage *and* its docs update ("roadmap → what works today") in-PR — there is no
+coverage *and* its docs update ("roadmap → what works today") in-PR, there is no
 separate test/e2e slice.
 
-- ✅ **Slice 1 — Reconnection + backoff.** `reconnecting` FSM state +
-  `RETRY` event; pure backoff module (`backoff.ts` — full-jitter math with
+- ✅ **Slice 1: Reconnection + backoff.** `reconnecting` FSM state +
+  `RETRY` event; pure backoff module (`backoff.ts`, full-jitter math with
   injectable randomness, deterministically unit-tested); retryable-close policy
   (user `close()` never retried; `shouldReconnect` veto; `maxRetries` budget);
   `reconnecting` event (`{ attempt, delay }`, ordered statechange → close →
@@ -520,16 +520,16 @@ separate test/e2e slice.
   (retries-exhausted / veto / user close-before-open); manual `connect()`
   during `reconnecting` skips the backoff wait. E2e: server drops the socket
   (code 1012) → real Chromium transparently reconnects and round-trips.
-- ✅ **Slice 2 — Message queueing.** `send()` queues during
+- ✅ **Slice 2: Message queueing.** `send()` queues during
   `connecting`/`reconnecting` (un-encoded values, so `drop` hands back exactly
   what was passed); bounded drop-oldest (`queue.ts`, default 256) with a `drop`
   event (`{ data, reason: "overflow" | "close" }`); flush in order on open,
   *before* the `open` event (backlog precedes anything an open-handler sends);
-  user `close()` and terminal failure drop the queue as `drop` events — never
+  user `close()` and terminal failure drop the queue as `drop` events, never
   silently lossy. `queueLength` joins `getState()`; `send()` still throws in
   `idle`/`closing`/`closed` and (always) under `queue: false`. E2e: a message
   sent while the server is down flushes after the transparent reconnect.
-- ✅ **Slice 3 — Idle detection / heartbeat.** Opt-in
+- ✅ **Slice 3: Idle detection / heartbeat.** Opt-in
   `heartbeat: { interval, message?, timeout? }` (`heartbeat.ts`; message
   defaults to `"ping"`, timeout to the interval). While open: ping every
   interval; *any* inbound frame counts as liveness; a silent deadline emits an
@@ -540,9 +540,9 @@ separate test/e2e slice.
   ("mute") → real Chromium detects the dead link via heartbeat and recovers on
   a fresh connection.
 
-### M4 — Adoption: docs, bindings, typed DX & 2.0 release ✅
+### M4: Adoption: docs, bindings, typed DX & 2.0 release ✅
 
-Renamed from "docs content & add-ons" — M4 is the **adoption milestone**. The
+Renamed from "docs content & add-ons", M4 is the **adoption milestone**. The
 premise (§2.1): libraries don't become popular at 1.0; they become popular when
 a developer copies a working hook or composable from a docs page.
 
@@ -551,14 +551,14 @@ a developer copies a working hook or composable from a docs page.
 - **Vue is a first-class binding, co-equal with React** (not a fast-follow).
   Rationale beyond preference: React WebSocket hooks are a crowded space
   (`react-use-websocket`, partysocket's hook); polished Vue support is
-  genuinely underserved — a niche we can own, and the maintainer dogfoods Vue.
+  genuinely underserved, a niche we can own, and the maintainer dogfoods Vue.
   Docs use each community's vocabulary: *composables* (Vue), *hooks* (React).
   Svelte remains a fast-follow.
 - **Bindings ship inside the one package as subpath exports**
-  (`durablews/vue`, `durablews/react`) — this is §5's existing
+  (`durablews/vue`, `durablews/react`), this is §5's existing
   one-package/subpath rule applied, re-affirmed for bindings specifically:
   one install, one npm page concentrating downloads (social proof), versioning
-  that can never drift from core, IDE-discoverable exports — Hono-style, vs.
+  that can never drift from core, IDE-discoverable exports, Hono-style, vs.
   the TanStack/XState separate-package model whose independent-versioning win
   costs fragmentation we have no team to absorb. Mechanics: `vue`/`react` as
   **optional peerDependencies** (`peerDependenciesMeta.optional`) so core
@@ -566,12 +566,12 @@ a developer copies a working hook or composable from a docs page.
   binding ever needs independent majors, extraction later is easy; merging
   back is hard.
 - **Reactive-state seam:** `on("statechange")` fires only on FSM transitions,
-  but `queueLength` changes on `send()` with no transition — insufficient for
+  but `queueLength` changes on `send()` with no transition, insufficient for
   reactive bindings. Slice 2 adds a small core `subscribe(listener)` seam
   firing on **any** observable-snapshot change (state, lastError, retryAttempt,
   queueLength); it is exactly React's `useSyncExternalStore` shape and drives
   Vue's `shallowRef` equally well.
-- **Alpha cadence:** publish `2.0.0-alpha.N` to npm as M4 slices merge —
+- **Alpha cadence:** publish `2.0.0-alpha.N` to npm as M4 slices merge,
   early adopters finding the library *is* the milestone's thesis; waiting for
   2.0.0 to publish anything contradicts it.
 
@@ -580,35 +580,35 @@ deliberate: typed maps stabilize the core surface first so bindings and the
 API reference are typed from day one; docs content lands after the surface
 stops moving; release is last.
 
-- ✅ **Slice 1 — Typed messages + Standard Schema validation.** Generics
-  threaded through the surface — `WebSocketClient<TIn, TOut>`:
+- ✅ **Slice 1: Typed messages + Standard Schema validation.** Generics
+  threaded through the surface, `WebSocketClient<TIn, TOut>`:
   `on("message")` receives `TIn`, `send()` accepts `TOut`, `drop` carries
   `DropEvent<TOut>`, middleware context is `MessageContext<TIn>` (defaults
   `unknown`, fully back-compatible). `config.schema` takes any **Standard
-  Schema** (interface vendored types-only per the spec — still zero deps);
+  Schema** (interface vendored types-only per the spec, still zero deps);
   `defineClient({ url, schema })` **infers `TIn` from the schema**, no
   generics needed. Validation runs decode → schema → middleware, so middleware
   only sees trusted data; invalid inbound surfaces as an `error` event
   (`SchemaValidationError` with the spec's issues), never as `message`; async
   `validate` supported. Compile-time tests via `expectTypeOf` + runtime
   validation suite.
-- ✅ **Slice 2 — Reactive seam + Vue & React bindings.** *(Landed as two PRs:
+- ✅ **Slice 2: Reactive seam + Vue & React bindings.** *(Landed as two PRs:
   2a the core seam; 2b the bindings.)* Core
-  `subscribe(listener)` over the full snapshot (per the decision above) —
+  `subscribe(listener)` over the full snapshot (per the decision above),
   including the `getState()` **snapshot caching** that referential-equality
-  consumers like `useSyncExternalStore` require — then
+  consumers like `useSyncExternalStore` require, then
   `durablews/vue` (`useWebSocket` composable: reactive state, auto-cleanup on
   scope dispose) and `durablews/react` (`useWebSocket` via
   `useSyncExternalStore`) as subpath exports with optional peers (`vue >=3.2`,
   `react >=18`). Shared semantics: pass a *config* and the binding owns the
   client (auto-connect, SSR-safe, closed on dispose/unmount); pass an
-  *existing client* and the binding only observes it — the app-singleton
+  *existing client* and the binding only observes it, the app-singleton
   sharing pattern. Both expose the snapshot fields plus a bounded
-  `lastMessage` (latest message only — core still never accumulates history)
+  `lastMessage` (latest message only, core still never accumulates history)
   and infer types from `config.schema`. Each has a docs page in its
   community's idiom (composables / hooks). First `2.0.0-alpha` publish with
   bindings included.
-- ✅ **Slice 3 — Outbound middleware.** Implements the settled §9 decision:
+- ✅ **Slice 3: Outbound middleware.** Implements the settled §9 decision:
   mirrored onion via the object form of `use()`
   (`use({ inbound?, outbound? })`; a bare function stays inbound). All five
   settled semantics shipped: transmission-time execution (after dequeue,
@@ -617,25 +617,25 @@ stops moving; release is last.
   per-message error isolation, heartbeat bypass. One semantic the design
   left implicit, now defined and tested: a message whose connection drops
   *mid-pipeline* is re-queued ahead of newer sends when a retry is underway
-  (middleware re-runs at next transmission — tokens stay fresh) and surfaces
-  as a `drop` otherwise — never silently lost. New types: `OutboundContext`,
+  (middleware re-runs at next transmission, tokens stay fresh) and surfaces
+  as a `drop` otherwise, never silently lost. New types: `OutboundContext`,
   `OutboundMiddleware`, `DirectionalMiddleware`. Corrects the §4.1 status
   note; e2e proves async stamping + ordering against a real socket.
-- ✅ **Slice 4 — Docs content.** API reference (hand-written single page —
+- ✅ **Slice 4: Docs content.** API reference (hand-written single page,
   typedoc deferred until the surface outgrows it), guides (durability
   tuning, middleware, codecs; framework pages landed in slice 2b),
-  migration-from-v1, the **comparison page** ("Why DurableWS?" — claims
+  migration-from-v1, the **comparison page** ("Why DurableWS?", claims
   verified against the incumbents' current READMEs, with an explicit
   "what they do better today" section: drop-in compat, dynamic URL
   providers, production miles), and **`llms.txt`** (hand-written, in
   `docs/public/`) for AI-assistant discovery. Also corrects §2.1's false
   "partysocket does not queue" claim (see the correction note there).
-- ✅ **Slice 5 — `durablews/compat` (decision: build, with scoped fidelity).**
-  `DurableWebSocket` (also exported as `WebSocket`) — an `EventTarget`-based,
+- ✅ **Slice 5: `durablews/compat` (decision: build, with scoped fidelity).**
+  `DurableWebSocket` (also exported as `WebSocket`), an `EventTarget`-based,
   `WebSocket`-shaped class over core for the two documented audiences:
   app-code one-line migration and **`webSocketImpl`-style injection**
   (graphql-ws, y-websocket examples in the docs). Wire-faithful by
-  construction (identity codec — no JSON); Level0 (`onopen`/…) + Level2
+  construction (identity codec, no JSON); Level0 (`onopen`/…) + Level2
   (`addEventListener`) event styles; constructor third arg takes the
   durablews config; the full client is exposed as `.client` (escape hatch to
   `drop`/`reconnecting`/middleware). The **known-deviations table** lives on
@@ -644,13 +644,13 @@ stops moving; release is last.
   stubs; post-construction `binaryType` emulated via order-preserving Blob
   conversion with a `FileReader` fallback for jsdom). Core gained one small
   option in support: `binaryType`, applied to the socket on every
-  (re)connect — generally useful for binary protocols, not compat-specific.
+  (re)connect, generally useful for binary protocols, not compat-specific.
   E2e: the compat class survives a server drop in real Chromium.
-- ✅ **Slice 6 — Cross-runtime e2e + distribution assets.** One smoke script
-  (`e2e/runtime-smoke.mjs` — lifecycle walk, JSON echo, transparent
+- ✅ **Slice 6: Cross-runtime e2e + distribution assets.** One smoke script
+  (`e2e/runtime-smoke.mjs`, lifecycle walk, JSON echo, transparent
   reconnect after a server drop, queue-flush-after-recovery) runs unchanged
   under **Node 22, Deno 2, and Bun** against the built bundle + a real echo
-  server, as three required CI jobs — §6's multi-runtime claim is now
+  server, as three required CI jobs, §6's multi-runtime claim is now
   proven, not stated (browser was already covered by Playwright).
   **size-limit** budgets enforced in CI (brotli, minified, all deps): core
   **3 KB** (measures 2.36), vue/react 3.5 KB, compat 4 KB; README badges
@@ -659,20 +659,20 @@ stops moving; release is last.
   `chat` (Vue + React against one server + one zod schema),
   `collab-notepad` (raw-WebSocket app made durable via the compat one-line
   swap). *Example-3 rescope, decided during implementation:* the planned
-  y-websocket/Yjs injection demo was dropped — y-websocket runs its own
+  y-websocket/Yjs injection demo was dropped, y-websocket runs its own
   reconnection (stateful sync protocols must), so injecting a
   self-reconnecting socket creates two fighting recovery layers; the
   **layering rule is now documented in the compat guide** ("one reconnector
   per stack", with a `reconnect: false` wrapper recipe), and the example
   demonstrates compat where it genuinely owns durability: plain-pipe code.
-- ✅ **Slice 7 — 2.0 release.** **`durablews@2.0.0` is live on npm `latest`**
+- ✅ **Slice 7: 2.0 release.** **`durablews@2.0.0` is live on npm `latest`**
   (published 2026-06-10 via OIDC trusted publishing, with provenance
-  attestations) — the maintainer merged the Version Packages PR (#40) as the
+  attestations), the maintainer merged the Version Packages PR (#40) as the
   deliberate human step. Release-pipeline hardening landed along the way:
   the Version PR's required checks never started because pushes made with
   the built-in `GITHUB_TOKEN` don't trigger workflows (GitHub's recursion
   guard); fixed by giving the `RELEASE_TOKEN` fine-grained PAT to **both**
-  the changesets step's env (#43) *and* `actions/checkout`'s `token` (#44 —
+  the changesets step's env (#43) *and* `actions/checkout`'s `token` (#44,
   the action pushes through git, which uses checkout's persisted
   credentials). Version PRs now arrive with live checks, unassisted.
   Remaining launch chore (outside the repo): flip the launch post to
@@ -681,31 +681,31 @@ stops moving; release is last.
 ## 9. Open questions
 
 - ~~Exact default values for reconnection (max retries, base delay, jitter, cap)
-  and idle timeout.~~ **Settled in M3** — reconnect: `baseDelay 500ms`,
+  and idle timeout.~~ **Settled in M3**: reconnect: `baseDelay 500ms`,
   `factor 2`, `maxDelay 30s`, full jitter, `maxRetries Infinity`; queue bounded
   at 256 (drop-oldest); idle detection opt-in (no default timeout). See M3 above.
 - ~~Whether `connect()` returns a promise that resolves on first open, and how
-  it interacts with auto-reconnect.~~ **Settled in M2** — resolves on first
+  it interacts with auto-reconnect.~~ **Settled in M2**: resolves on first
   open; idempotent; rejects only on terminal failure (see M2 above).
 - ~~Final primary-API surface (names of options, event names).~~ **Event names
-  settled in M2** — standard `WebSocket` vocabulary (`open`/`message`/`close`/
+  settled in M2**: standard `WebSocket` vocabulary (`open`/`message`/`close`/
   `error`/`statechange`). Option names refined as each seam lands.
 - Whether channels are the only plugin-shaped feature (which would let us drop
   the umbrella "plugin" concept from the public vocabulary).
-- **AsyncAPI / OpenAPI integration (v2.x idea — recorded 2026-06-09, not
-  scheduled).** OpenAPI itself cannot describe WebSocket message flows — it
+- **AsyncAPI / OpenAPI integration (v2.x idea, recorded 2026-06-09, not
+  scheduled).** OpenAPI itself cannot describe WebSocket message flows, it
   is an HTTP request/response spec; the async-world equivalent is
   **AsyncAPI**, which has first-class WebSocket bindings (channels, message
   schemas). Core already has the right seams and needs nothing added:
   `schema` accepts any Standard Schema, so an AsyncAPI document's message
   schemas (JSON Schema) can validate inbound traffic today through a
   json-schema→Standard-Schema adapter. The product-shaped idea is
-  **codegen** — a `durablews-asyncapi` tool that generates a typed client
+  **codegen**: a `durablews-asyncapi` tool that generates a typed client
   (channel definitions, message unions, validators) from an AsyncAPI
   document. Post-2.0 growth item, alongside the socket.io codec.
-- **OpenTelemetry (v2.x idea — recorded 2026-06-10, not scheduled).** Core
+- **OpenTelemetry (v2.x idea, recorded 2026-06-10, not scheduled).** Core
   needs nothing: the existing seams already expose every signal an
-  instrumentation wants — middleware (both directions) for message
+  instrumentation wants, middleware (both directions) for message
   spans/counts, `subscribe()`/`getState()` for state and queue-depth
   metrics, and the event vocabulary (`reconnecting`, `drop`, `error`,
   close code 4408) for the durability story. The product-shaped version is
@@ -713,21 +713,21 @@ stops moving; release is last.
   `@opentelemetry/api` as an optional peer, like the framework bindings).
   Honest caveats before scheduling it: OTel has **no stable semantic
   conventions for WebSockets** (we'd be inventing attribute names), and
-  browser-side OTel adoption is thin — the audience is Node/edge
+  browser-side OTel adoption is thin, the audience is Node/edge
   service-to-service clients, real but a minority. Decide on demand;
   userland can build it today against the public seams.
 - ~~`connect()` can never settle under default config.~~ **Settled in M3
   slice 1: pending-forever is by design.** Under `maxRetries: Infinity` the
-  client is *still working* — a rejection would be a lie, and a built-in
+  client is *still working*, a rejection would be a lie, and a built-in
   `connectTimeout` would duplicate what userland does in one line
   (`Promise.race([client.connect(), timeout(ms)])`) while complicating the
   contract. Escape hatches: finite `maxRetries`, `shouldReconnect`, or the
   race. Documented prominently in the `connect()` JSDoc and getting-started.
-- ~~`durablews/compat` — build or reject?~~ **Settled: build, with scoped
-  fidelity** (M4 slice 5). Faithful for two documented use cases — app-code
-  drop-in and `webSocketImpl`-style injection — with a published known-
+- ~~`durablews/compat`, build or reject?~~ **Settled: build, with scoped
+  fidelity** (M4 slice 5). Faithful for two documented use cases, app-code
+  drop-in and `webSocketImpl`-style injection, with a published known-
   deviations table rather than spec perfection. See §8 M4 slice 5.
-- ~~**Outbound middleware shape** — same onion pipeline mirrored, or a distinct
+- ~~**Outbound middleware shape**: same onion pipeline mirrored, or a distinct
   hook (`onSend`)? Auth (token attach/refresh) is the driving use case.~~
   **Settled (M4 slice 3 design): mirrored onion, registered through an object
   form of `use()`.** A bare function stays inbound (unchanged, the common
@@ -741,8 +741,8 @@ stops moving; release is last.
                                                        // directions
   ```
 
-  Why an onion and not an `onSend` hook: the driving use case — attaching a
-  *fresh* auth token, refreshing it when expired — is **async and
+  Why an onion and not an `onSend` hook: the driving use case, attaching a
+  *fresh* auth token, refreshing it when expired, is **async and
   composable**, exactly what a hook is not. One pipeline model for both
   directions also keeps the mental model singular ("middleware intercepts
   messages"), and the object form gives a logical middleware (auth, logging,
@@ -751,7 +751,7 @@ stops moving; release is last.
 
   Semantics (the load-bearing decisions):
 
-  - **Runs at transmission time** — after dequeue, before `codec.encode` —
+  - **Runs at transmission time**: after dequeue, before `codec.encode`,
     not at `send()` time. A message queued across a 30s reconnect gets a
     token that is fresh *when it actually goes out* (the entire point of the
     use case), and the queue keeps storing exactly what the user passed to
@@ -761,49 +761,49 @@ stops moving; release is last.
     refresh); the outbound path serializes so messages reach the socket in
     `send()` order even when an earlier message's middleware awaits. When no
     middleware returns a promise (the common case), `send()` stays fully
-    synchronous — zero overhead.
+    synchronous, zero overhead.
   - **Short-circuit = not sent, silently.** Returning without calling
-    `next()` is deliberate policy (filtering), not durability loss — no
+    `next()` is deliberate policy (filtering), not durability loss, no
     `drop` event (`drop` means "the library couldn't deliver this", not "you
     chose not to send it").
   - **Errors are per-message.** A throw/rejection surfaces as an `error`
     event; that message is not sent; subsequent messages continue (same
     isolation the queue flush already has).
   - **Heartbeat pings bypass outbound middleware.** They are transport-level
-    liveness, not app messages — an auth or logging middleware seeing
+    liveness, not app messages, an auth or logging middleware seeing
     synthetic pings would be surprising, and a middleware that drops or
     delays them would silently break dead-link detection.
 
-  Use-case grounding — async is required by the platform, not hypothetical:
+  Use-case grounding, async is required by the platform, not hypothetical:
 
-  - **Auth token refresh** — await the refresh endpoint, attach, send (the
+  - **Auth token refresh**: await the refresh endpoint, attach, send (the
     driving case).
-  - **Payload signing / encryption** — WebCrypto (`crypto.subtle.sign` /
+  - **Payload signing / encryption**: WebCrypto (`crypto.subtle.sign` /
     `.encrypt`) has *no synchronous API*; E2E-encrypted or HMAC-signed
     messages require async middleware.
-  - **Compression** — `CompressionStream` is likewise async-only.
-  - **Pacing** — a semaphore/throttle that awaits a send slot, preserving
+  - **Compression**: `CompressionStream` is likewise async-only.
+  - **Pacing**: a semaphore/throttle that awaits a send slot, preserving
     order.
-  - **Outbox journaling** — await an IndexedDB write before transmit, for
+  - **Outbox journaling**: await an IndexedDB write before transmit, for
     exactly-once-across-page-reloads semantics.
 
   And one boundary stated honestly. The pipeline transforms **the stream of
-  already-committed messages**, and order is part of what the stream means —
+  already-committed messages**, and order is part of what the stream means,
   so ordered delivery implies head-of-line blocking: a middleware that
   delays one message delays everything behind it. That is *correct* for
   every case above (pacing means delaying the whole stream; a token refresh
-  blocking sends is what freshness requires). The alternative — running
-  per-message pipelines concurrently and writing in completion order —
+  blocking sends is what freshness requires). The alternative, running
+  per-message pipelines concurrently and writing in completion order,
   silently reorders messages whenever latencies differ, a data-corrupting
   failure mode for any create-then-update sequence.
 
   Policies that decide **whether and when a `send()` call becomes a message
-  at all** — per-key debounce, batching, dedupe — are a different
+  at all** (per-key debounce, batching, dedupe) are a different
   *composition layer*, not a different mechanism. As middleware they would
   have to hold message N while letting N+1 pass (reordering, which the
   pipeline refuses) and would see every message, needing filter config to
   scope themselves. As plain wrappers in front of `send()` they get both
-  for free, and remain fully composable — function composition at the call
+  for free, and remain fully composable, function composition at the call
   site instead of pipeline composition over the stream:
 
   ```ts
@@ -811,12 +811,12 @@ stops moving; release is last.
   ```
 
   Nothing here is "built in instead": such wrappers are userland (at most a
-  future recipes page / helpers module of send-wrappers — decide on demand,
+  future recipes page / helpers module of send-wrappers, decide on demand,
   M4 slice 4 at the earliest), and core ships neither. This is the layering
-  every middleware system has — rate limiting is Express/Hono middleware,
+  every middleware system has, rate limiting is Express/Hono middleware,
   request coalescing happens in the caller; TCP batches via Nagle but never
   reorders your bytes. Routing decomposes the same way: inbound routing
   (dispatch by message type) is inbound middleware today and the channels
-  plugin (§4.6) tomorrow; the outbound half is enveloping — stamping
-  topic/destination onto each frame — a plain sync transform.
+  plugin (§4.6) tomorrow; the outbound half is enveloping, stamping
+  topic/destination onto each frame, a plain sync transform.
 ```

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,7 +1,7 @@
 # RFCs
 
 Design documents for decisions that are **expensive to reverse** or whose
-**reasoning should be findable years later** — public API shape, packaging
+**reasoning should be findable years later**: public API shape, packaging
 and export structure, protocol semantics. Routine features and fixes don't
 need an RFC: an issue and a PR are their own record (see
 [Proposing changes](../CONTRIBUTING.md#proposing-changes) in the
@@ -12,7 +12,7 @@ contributing guide). The live plan for what's being built next is
 
 1. Create `rfcs/NNNN-short-slug.md` using the next free number (four
    digits, kebab-case slug) and the header block below.
-2. Open a PR. The PR discussion **is** the review — no separate forum, no
+2. Open a PR. The PR discussion **is** the review, no separate forum, no
    fixed comment window.
 3. When the PR merges, the RFC is **Accepted** and work can be scheduled.
 4. Keep the status current as work proceeds. Once the work ships, the RFC
@@ -22,7 +22,7 @@ contributing guide). The live plan for what's being built next is
 Header block:
 
 ````md
-# RFC NNNN — Title
+# RFC NNNN, Title
 
 - **Status:** Draft | Accepted | Implemented | Superseded
 - **Author:** …


### PR DESCRIPTION
Repo-wide cosmetic sweep removing em-dashes (and en-dash ranges) from all markdown/mdx, per the standing no-em-dash writing rule.

Not a blind comma swap: paired asides became parentheses, `Slice N`/`MN` labels and bold-term definitions became colons, lone dashes became commas, `M1-M4`-style ranges became hyphens. A few paired and cross-line cases were hand-fixed. 24 files, punctuation only, no content or meaning changes. Docs build verified locally.

(RFC 0002 in #53 was already written em-dash-free and isn't touched here.)