### PR TITLE
feat(middleware): durablews/middleware pack + auth (RFC 0002 slice 1)

### DIFF
--- a/.changeset/middleware-pack-auth.md
+++ b/.changeset/middleware-pack-auth.md
@@ -1,0 +1,7 @@
+---
+"durablews": minor
+---
+
+Add `durablews/middleware`, a tree-shakable pack of built-in middleware (RFC 0002), starting with `auth`. Import only what you use; unused middleware add zero bundle bytes.
+
+`auth({ token, inject })` is outbound middleware that resolves a credential at transmission time and injects it into each message, so a message queued across a reconnect still goes out with a fresh token.

--- a/docs/src/content/docs/guides/middleware.md
+++ b/docs/src/content/docs/guides/middleware.md
@@ -95,6 +95,37 @@ Same composability, different layer, and unrelated messages never wait.
   silently lost.
 - **Heartbeat pings bypass outbound middleware** entirely.
 
+## The built-in pack
+
+Common middleware ship in a tree-shakable subpath, `durablews/middleware`.
+Import only what you use; the rest adds zero bundle bytes, because the package
+is side-effect-free and bundlers drop unreferenced exports. (Importing just
+`auth`, for example, is well under 100 bytes, enforced in CI.)
+
+### `auth`
+
+The flagship outbound case as a ready-made helper: it resolves a credential at
+transmission time and injects it into each outgoing message.
+
+```ts
+import { defineClient } from "durablews";
+import { auth } from "durablews/middleware";
+
+const client = defineClient({ url }).use(
+    auth({
+        token: () => getAccessToken(),            // may be async
+        inject: (data, token) => ({ ...data, token })
+    })
+);
+```
+
+`inject` is required: messages are app-shaped, so there is no universal place
+to put a token. Because the token resolves at transmission time, a message
+queued across a reconnect still goes out with a current one. If `token()`
+throws or rejects, that one message is not sent and the failure surfaces as an
+`error` event (later messages are unaffected), per the outbound failure
+semantics above.
+
 ## Writing middleware once, typing it
 
 Middleware is typed by the client's generics: inbound contexts carry `TIn`,

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -46,6 +46,16 @@
                 "types": "./dist/compat.d.cts",
                 "default": "./dist/compat.cjs"
             }
+        },
+        "./middleware": {
+            "import": {
+                "types": "./dist/middleware.d.ts",
+                "default": "./dist/middleware.js"
+            },
+            "require": {
+                "types": "./dist/middleware.d.cts",
+                "default": "./dist/middleware.cjs"
+            }
         }
     },
     "sideEffects": false,
@@ -163,6 +173,13 @@
             "name": "durablews/compat",
             "path": "dist/compat.js",
             "limit": "4 KB",
+            "brotli": true
+        },
+        {
+            "name": "durablews/middleware (auth only, tree-shaken)",
+            "path": "dist/middleware.js",
+            "import": "{ auth }",
+            "limit": "0.15 KB",
             "brotli": true
         }
     ]

--- a/packages/durablews/src/index.ts
+++ b/packages/durablews/src/index.ts
@@ -39,7 +39,7 @@ export function defineClient(config: WebSocketClientConfig): WebSocketClient {
 export { RECONNECT_DEFAULTS } from "@/backoff";
 export { jsonCodec } from "@/codec";
 export { HEARTBEAT_TIMEOUT_CODE } from "@/heartbeat";
-export { pingpong } from "@/middleware";
+export { pingpong } from "@/middleware/pingpong";
 export { QUEUE_DEFAULTS } from "@/queue";
 export type { StandardSchemaV1 } from "@/schema";
 export { SchemaValidationError } from "@/schema";

--- a/packages/durablews/src/middleware/auth.ts
+++ b/packages/durablews/src/middleware/auth.ts
@@ -1,0 +1,56 @@
+import type { DirectionalMiddleware } from "@/types";
+
+/**
+ * Options for {@link auth}.
+ */
+export interface AuthOptions<TOut = unknown> {
+    /**
+     * Produces the current credential. Called at **transmission time** for
+     * every outbound message, so a message queued across a reconnect is sent
+     * with a token that is fresh when it actually goes out, not when `send()`
+     * was first called. May be async (e.g. await a refresh endpoint).
+     */
+    token: () => string | Promise<string>;
+    /**
+     * Injects the token into the outgoing message and returns the value to
+     * send. Required: messages are app-shaped, so there is no universal
+     * placement. The queue and `drop` events keep the original untouched.
+     */
+    inject: (data: TOut, token: string) => TOut;
+}
+
+/**
+ * Outbound middleware that injects a fresh credential into every outgoing
+ * message, resolved at transmission time.
+ *
+ * The hard parts (transmission-time execution, ordered async) are in the core
+ * pipeline; this is the small, correct glue over them. Because the token is
+ * resolved when the message actually goes out, a message that was queued
+ * across a 30s reconnect still carries a current token.
+ *
+ * ```typescript
+ * import { defineClient } from "durablews";
+ * import { auth } from "durablews/middleware";
+ *
+ * const ws = defineClient({ url }).use(
+ *     auth({
+ *         token: () => getAccessToken(),            // may be async
+ *         inject: (data, token) => ({ ...data, token })
+ *     })
+ * );
+ * ```
+ *
+ * If `token()` throws or rejects, that one message is not sent and the failure
+ * surfaces as an `error` event; later messages are unaffected.
+ */
+export function auth<TOut = unknown>(
+    options: AuthOptions<TOut>
+): DirectionalMiddleware<unknown, TOut> {
+    return {
+        outbound: async (ctx, next) => {
+            const token = await options.token();
+            ctx.data = options.inject(ctx.data, token);
+            await next();
+        }
+    };
+}

--- a/packages/durablews/src/middleware/index.ts
+++ b/packages/durablews/src/middleware/index.ts
@@ -1,0 +1,8 @@
+/**
+ * `durablews/middleware`: the built-in middleware pack.
+ *
+ * Named, side-effect-free exports: import only what you use and the rest is
+ * tree-shaken away (the package sets `"sideEffects": false`). See RFC 0002.
+ */
+export { type AuthOptions, auth } from "@/middleware/auth";
+export { pingpong } from "@/middleware/pingpong";

--- a/packages/durablews/src/middleware/pingpong.ts
+++ b/packages/durablews/src/middleware/pingpong.ts
@@ -4,7 +4,7 @@ import type { Middleware } from "@/types";
  * Replies to a textual `"ping"` with `"pong"` and stops the message there
  * (it is not emitted as a `message` event). A common keepalive convention.
  *
- * Opt in explicitly — it is not registered by default:
+ * Opt in explicitly, it is not registered by default:
  *
  * ```typescript
  * import { defineClient, pingpong } from "durablews";

--- a/packages/durablews/tests/middleware/auth.test.ts
+++ b/packages/durablews/tests/middleware/auth.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// https://github.com/akiomik/vitest-websocket-mock
+import WS from "vitest-websocket-mock";
+import { client } from "../../src/client";
+import { auth } from "../../src/middleware/auth";
+import type { WebSocketClient } from "../../src/types";
+
+const URL = "ws://localhost:1234";
+
+describe("auth middleware", () => {
+    let server: WS;
+
+    beforeEach(() => {
+        server = new WS(URL);
+    });
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    async function open(ws: WebSocketClient<unknown, unknown>) {
+        const opened = ws.connect();
+        await server.connected;
+        await opened;
+    }
+
+    it("attaches a token to each outbound message", async () => {
+        const ws: WebSocketClient<unknown, { type: string }> = client({
+            url: URL,
+            reconnect: false
+        });
+        ws.use(
+            auth<{ type: string }>({
+                token: () => "t0ken",
+                inject: (data, token) => ({ ...data, token })
+            })
+        );
+        await open(ws);
+
+        ws.send({ type: "hi" });
+        await expect(server).toReceiveMessage(
+            JSON.stringify({ type: "hi", token: "t0ken" })
+        );
+        ws.close();
+    });
+
+    it("resolves the token at transmission time, fresh per message", async () => {
+        const ws: WebSocketClient<unknown, { type: string }> = client({
+            url: URL,
+            reconnect: false
+        });
+        let n = 0;
+        ws.use(
+            auth<{ type: string }>({
+                token: () => `t${n++}`,
+                inject: (data, token) => ({ ...data, token })
+            })
+        );
+        await open(ws);
+
+        ws.send({ type: "a" });
+        await expect(server).toReceiveMessage(
+            JSON.stringify({ type: "a", token: "t0" })
+        );
+        ws.send({ type: "b" });
+        await expect(server).toReceiveMessage(
+            JSON.stringify({ type: "b", token: "t1" })
+        );
+        ws.close();
+    });
+
+    it("awaits an async token and preserves send order", async () => {
+        const ws: WebSocketClient<unknown, { n: number }> = client({
+            url: URL,
+            reconnect: false
+        });
+        ws.use(
+            auth<{ n: number }>({
+                token: async () => "async-token",
+                inject: (data, token) => ({ ...data, token })
+            })
+        );
+        await open(ws);
+
+        ws.send({ n: 1 });
+        ws.send({ n: 2 });
+        await expect(server).toReceiveMessage(
+            JSON.stringify({ n: 1, token: "async-token" })
+        );
+        await expect(server).toReceiveMessage(
+            JSON.stringify({ n: 2, token: "async-token" })
+        );
+        ws.close();
+    });
+
+    it("surfaces a token failure as an error and sends later messages", async () => {
+        const ws: WebSocketClient<unknown, { n: number }> = client({
+            url: URL,
+            reconnect: false
+        });
+        let calls = 0;
+        ws.use(
+            auth<{ n: number }>({
+                token: () => {
+                    calls += 1;
+                    if (calls === 1) {
+                        throw new Error("refresh failed");
+                    }
+                    return "ok";
+                },
+                inject: (data, token) => ({ ...data, token })
+            })
+        );
+        const onError = vi.fn();
+        ws.on("error", onError);
+        await open(ws);
+
+        ws.send({ n: 1 }); // token throws: not sent, surfaces as error
+        ws.send({ n: 2 }); // continues
+
+        await expect(server).toReceiveMessage(
+            JSON.stringify({ n: 2, token: "ok" })
+        );
+        expect(onError).toHaveBeenCalledTimes(1);
+        ws.close();
+    });
+});

--- a/packages/durablews/tsup.config.ts
+++ b/packages/durablews/tsup.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-    entry: ["src/index.ts", "src/vue.ts", "src/react.ts", "src/compat.ts"],
+    entry: {
+        index: "src/index.ts",
+        vue: "src/vue.ts",
+        react: "src/react.ts",
+        compat: "src/compat.ts",
+        middleware: "src/middleware/index.ts"
+    },
     format: ["esm", "cjs"],
     dts: true,
     clean: true,


### PR DESCRIPTION
First implementation slice of [RFC 0002](https://github.com/imnsco/DurableWS/blob/main/rfcs/0002-built-in-middleware.md): the tree-shakable `durablews/middleware` subpath and its first member, `auth`.

**What's here**
- `src/middleware/` folder, one file per middleware. `pingpong` moved in; core re-exports it directly (`@/middleware/pingpong`) so the core bundle never touches the pack barrel.
- **`auth({ token, inject })`** — outbound middleware that resolves a credential at transmission time and injects it into each message. A message queued across a reconnect still goes out with a *fresh* token. `inject` is required (messages are app-shaped). A `token()` failure surfaces as an `error` event and skips only that message.
- Subpath wired via tsup object-entries (`dist/middleware.js`) + exports map.
- **Tree-shake canary**: a size-limit entry importing only `auth` measures **~65 B** (budget 150 B) — proof that unused pack members add zero bundle bytes.
- 4 tests (attach, fresh-per-message, async ordering, error isolation), a middleware-guide section, and a minor changeset.

**Green locally**: typecheck, biome, 160 tests, `check:publish` (all subpaths 🟢), size budgets, docs build.

Does not resolve RFC 0002's open questions (outbound validation, backpressure fork, the `InboundMiddleware` alias) — those come with later slices.