### PR TITLE
feat(middleware): logger (RFC 0002 slice 2)

### DIFF
--- a/.changeset/middleware-logger.md
+++ b/.changeset/middleware-logger.md
@@ -1,0 +1,5 @@
+---
+"durablews": minor
+---
+
+Add `logger` to `durablews/middleware`: structured logging of every message in both directions, with a `redact` hook that scrubs secrets/PII for the logs only (the wire and your handlers see the real message). Tree-shakable, like the rest of the pack.

--- a/docs/src/content/docs/guides/middleware.md
+++ b/docs/src/content/docs/guides/middleware.md
@@ -126,6 +126,30 @@ throws or rejects, that one message is not sent and the failure surfaces as an
 `error` event (later messages are unaffected), per the outbound failure
 semantics above.
 
+### `logger`
+
+Logs every message in both directions without altering it.
+
+```ts
+import { logger } from "durablews/middleware";
+
+client.use(
+    logger({
+        redact: (data) => ({
+            ...(data as Record<string, unknown>),
+            token: "[redacted]"
+        })
+    })
+);
+```
+
+Each entry carries the `direction`, the `data` (after `redact`), a
+`timestamp`, and the connection `state`. The production-grade part is
+`redact`: it scrubs secrets and PII *for the logs only*, so the wire and your
+handlers always see the real message and an auth token never lands in a log.
+Defaults: log to `console.debug`, both directions, no redaction. Narrow with
+`direction: "inbound" | "outbound"`.
+
 ## Writing middleware once, typing it
 
 Middleware is typed by the client's generics: inbound contexts carry `TIn`,

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -181,6 +181,13 @@
             "import": "{ auth }",
             "limit": "0.15 KB",
             "brotli": true
+        },
+        {
+            "name": "durablews/middleware (logger only, tree-shaken)",
+            "path": "dist/middleware.js",
+            "import": "{ logger }",
+            "limit": "0.3 KB",
+            "brotli": true
         }
     ]
 }

--- a/packages/durablews/src/middleware/index.ts
+++ b/packages/durablews/src/middleware/index.ts
@@ -5,4 +5,5 @@
  * tree-shaken away (the package sets `"sideEffects": false`). See RFC 0002.
  */
 export { type AuthOptions, auth } from "@/middleware/auth";
+export { type LogEntry, type LoggerOptions, logger } from "@/middleware/logger";
 export { pingpong } from "@/middleware/pingpong";

--- a/packages/durablews/src/middleware/logger.ts
+++ b/packages/durablews/src/middleware/logger.ts
@@ -1,0 +1,95 @@
+import type {
+    ConnectionState,
+    DirectionalMiddleware,
+    Middleware,
+    OutboundMiddleware
+} from "@/types";
+
+/**
+ * One logged message, in either direction.
+ */
+export interface LogEntry {
+    /** Which way the message was flowing. */
+    direction: "inbound" | "outbound";
+    /** The message, after {@link LoggerOptions.redact} if one was given. */
+    data: unknown;
+    /** `Date.now()` when the message was logged. */
+    timestamp: number;
+    /** The connection state at log time. */
+    state: ConnectionState;
+}
+
+/**
+ * Options for {@link logger}.
+ */
+export interface LoggerOptions {
+    /**
+     * Where entries go. Defaults to `console.debug`. Swap in your structured
+     * logger to pipe traffic into an observability stack.
+     */
+    log?: (entry: LogEntry) => void;
+    /**
+     * Scrub secrets/PII before logging. Receives the message and returns what
+     * to log; the original is never altered, so the wire and your handlers are
+     * unaffected. Defaults to logging the message as-is.
+     */
+    redact?: (data: unknown) => unknown;
+    /** Which direction(s) to log. Defaults to `"both"`. */
+    direction?: "inbound" | "outbound" | "both";
+}
+
+/**
+ * Logs every message passing through the client, in both directions, without
+ * altering it.
+ *
+ * The production-grade part is {@link LoggerOptions.redact}: structured output
+ * with secrets and PII scrubbed, so you never leak an auth token into your
+ * logs.
+ *
+ * ```typescript
+ * import { defineClient } from "durablews";
+ * import { logger } from "durablews/middleware";
+ *
+ * const ws = defineClient({ url }).use(
+ *     logger({
+ *         redact: (data) => ({ ...data, token: "[redacted]" })
+ *     })
+ * );
+ * ```
+ */
+export function logger(options: LoggerOptions = {}): DirectionalMiddleware {
+    const sink =
+        options.log ?? ((entry) => console.debug("[durablews]", entry));
+    const redact = options.redact ?? ((data: unknown) => data);
+    const direction = options.direction ?? "both";
+
+    const record = (
+        dir: LogEntry["direction"],
+        data: unknown,
+        state: ConnectionState
+    ): void => {
+        sink({
+            direction: dir,
+            data: redact(data),
+            timestamp: Date.now(),
+            state
+        });
+    };
+
+    const inbound: Middleware = (ctx, next) => {
+        record("inbound", ctx.data, ctx.client.state);
+        return next();
+    };
+    const outbound: OutboundMiddleware = (ctx, next) => {
+        record("outbound", ctx.data, ctx.client.state);
+        return next();
+    };
+
+    if (direction === "inbound") {
+        return { inbound };
+    }
+    if (direction === "outbound") {
+        return { outbound };
+    }
+    return { inbound, outbound };
+}

--- a/packages/durablews/tests/middleware/logger.test.ts
+++ b/packages/durablews/tests/middleware/logger.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// https://github.com/akiomik/vitest-websocket-mock
+import WS from "vitest-websocket-mock";
+import { client } from "../../src/client";
+import { type LogEntry, logger } from "../../src/middleware/logger";
+import type { WebSocketClient } from "../../src/types";
+
+const URL = "ws://localhost:1234";
+
+describe("logger middleware", () => {
+    let server: WS;
+
+    beforeEach(() => {
+        server = new WS(URL);
+    });
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    async function open(ws: WebSocketClient<unknown, unknown>) {
+        const opened = ws.connect();
+        await server.connected;
+        await opened;
+    }
+
+    it("logs outbound and inbound messages with direction, state, timestamp", async () => {
+        const entries: LogEntry[] = [];
+        const ws = client({ url: URL, reconnect: false });
+        ws.use(logger({ log: (e) => entries.push(e) }));
+        await open(ws);
+
+        ws.send({ hello: "world" });
+        await expect(server).toReceiveMessage(
+            JSON.stringify({ hello: "world" })
+        );
+        server.send(JSON.stringify({ pong: true }));
+
+        const outbound = entries.find((e) => e.direction === "outbound");
+        const inbound = entries.find((e) => e.direction === "inbound");
+        expect(outbound?.data).toEqual({ hello: "world" });
+        expect(inbound?.data).toEqual({ pong: true });
+        expect(outbound?.state).toBe("open");
+        expect(typeof outbound?.timestamp).toBe("number");
+        ws.close();
+    });
+
+    it("redacts before logging without altering the wire or handlers", async () => {
+        const entries: LogEntry[] = [];
+        const onMessage = vi.fn();
+        const ws = client({ url: URL, reconnect: false });
+        ws.use(
+            logger({
+                log: (e) => entries.push(e),
+                redact: (data) => ({
+                    ...(data as Record<string, unknown>),
+                    token: "[redacted]"
+                })
+            })
+        );
+        ws.on("message", onMessage);
+        await open(ws);
+
+        ws.send({ token: "secret-abc" });
+        // The wire sees the real value, not the redacted one.
+        await expect(server).toReceiveMessage(
+            JSON.stringify({ token: "secret-abc" })
+        );
+
+        server.send(JSON.stringify({ token: "secret-xyz" }));
+        // The handler sees the real value too.
+        expect(onMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ token: "secret-xyz" })
+        );
+        // Only the logs are scrubbed.
+        expect(
+            entries.every(
+                (e) => (e.data as { token: string }).token === "[redacted]"
+            )
+        ).toBe(true);
+        ws.close();
+    });
+
+    it("honors direction: outbound only", async () => {
+        const entries: LogEntry[] = [];
+        const ws = client({ url: URL, reconnect: false });
+        ws.use(logger({ log: (e) => entries.push(e), direction: "outbound" }));
+        await open(ws);
+
+        ws.send({ a: 1 });
+        await expect(server).toReceiveMessage(JSON.stringify({ a: 1 }));
+        server.send(JSON.stringify({ b: 2 }));
+
+        expect(entries.every((e) => e.direction === "outbound")).toBe(true);
+        expect(entries).toHaveLength(1);
+        ws.close();
+    });
+});


### PR DESCRIPTION
Second member of the `durablews/middleware` pack ([RFC 0002](https://github.com/imnsco/DurableWS/blob/main/rfcs/0002-built-in-middleware.md)): **`logger`**.

- `logger({ log?, redact?, direction? })` — structured logging of every message in both directions, never altering it. Each `LogEntry` has `direction`, `data` (after `redact`), `timestamp`, and connection `state`.
- **`redact` is the production part**: it scrubs secrets/PII *for the logs only*, so the wire and your handlers always see the real message and a token never lands in a log.
- Defaults: `console.debug`, both directions, no redaction; `direction` narrows to one side.

**Tree-shake cross-check**: importing only `logger` measures ~176 B, and the `auth`-only canary **stays 66 B** with logger now in the pack, so siblings genuinely aren't dragged in.

Green locally: typecheck, biome, 163 tests, `check:publish` (all 🟢), size budgets, docs build. Holding for your nod to merge.