### PR TITLE
feat(middleware): dedup (RFC 0002 slice 3a)

### DIFF
--- a/.changeset/middleware-dedup.md
+++ b/.changeset/middleware-dedup.md
@@ -1,0 +1,5 @@
+---
+"durablews": minor
+---
+
+Add `dedup` to `durablews/middleware`: inbound middleware that drops duplicate messages (by a `key` you extract), so a server that redelivers never reaches your handler twice. Memory is bounded by `window` (drop-oldest), like the core send queue. Tree-shakable, like the rest of the pack.

--- a/docs/src/content/docs/guides/middleware.md
+++ b/docs/src/content/docs/guides/middleware.md
@@ -150,6 +150,23 @@ handlers always see the real message and an auth token never lands in a log.
 Defaults: log to `console.debug`, both directions, no redaction. Narrow with
 `direction: "inbound" | "outbound"`.
 
+### `dedup`
+
+Drops inbound duplicates, so a server that redelivers (at-least-once) never
+reaches your handler twice.
+
+```ts
+import { dedup } from "durablews/middleware";
+
+client.use(dedup({ key: (m) => (m as { id: string }).id }));
+```
+
+`key` is required (messages have no built-in id). Memory is bounded by
+`window` (default 1000, drop-oldest), in the same spirit as the core send
+queue: a duplicate that arrives more than `window` distinct messages later is
+no longer detected, but memory never grows without limit. A duplicate is
+short-circuited, so it never reaches a `message` handler.
+
 ## Writing middleware once, typing it
 
 Middleware is typed by the client's generics: inbound contexts carry `TIn`,

--- a/packages/durablews/package.json
+++ b/packages/durablews/package.json
@@ -188,6 +188,13 @@
             "import": "{ logger }",
             "limit": "0.3 KB",
             "brotli": true
+        },
+        {
+            "name": "durablews/middleware (dedup only, tree-shaken)",
+            "path": "dist/middleware.js",
+            "import": "{ dedup }",
+            "limit": "0.25 KB",
+            "brotli": true
         }
     ]
 }

--- a/packages/durablews/src/middleware/dedup.ts
+++ b/packages/durablews/src/middleware/dedup.ts
@@ -1,0 +1,60 @@
+import type { DirectionalMiddleware } from "@/types";
+
+/**
+ * Options for {@link dedup}.
+ */
+export interface DedupOptions {
+    /**
+     * Extracts the identity of a message. Two inbound messages with the same
+     * key are treated as duplicates. Required: messages have no built-in id.
+     */
+    key: (data: unknown) => string;
+    /**
+     * How many recent keys to remember. Bounded, drop-oldest: once the limit
+     * is reached the oldest key is forgotten (a duplicate that arrives later
+     * than `window` distinct messages ago is no longer detected). Default
+     * `1000`.
+     */
+    window?: number;
+}
+
+/**
+ * Inbound middleware that drops duplicate messages, so a server that
+ * redelivers (at-least-once) never reaches your handler twice.
+ *
+ * Memory is bounded by `window` (drop-oldest), in the same spirit as the core
+ * send queue: never silently unbounded.
+ *
+ * ```typescript
+ * import { defineClient } from "durablews";
+ * import { dedup } from "durablews/middleware";
+ *
+ * const ws = defineClient({ url }).use(
+ *     dedup({ key: (m) => (m as { id: string }).id })
+ * );
+ * ```
+ *
+ * A duplicate is short-circuited: it is not emitted as a `message` event (and
+ * no `drop` event fires, since that is reserved for outbound delivery loss).
+ */
+export function dedup(options: DedupOptions): DirectionalMiddleware {
+    const max = options.window ?? 1000;
+    const seen = new Set<string>();
+
+    return {
+        inbound: (ctx, next) => {
+            const k = options.key(ctx.data);
+            if (seen.has(k)) {
+                return;
+            }
+            seen.add(k);
+            if (seen.size > max) {
+                const oldest = seen.values().next().value;
+                if (oldest !== undefined) {
+                    seen.delete(oldest);
+                }
+            }
+            return next();
+        }
+    };
+}

--- a/packages/durablews/src/middleware/index.ts
+++ b/packages/durablews/src/middleware/index.ts
@@ -5,5 +5,6 @@
  * tree-shaken away (the package sets `"sideEffects": false`). See RFC 0002.
  */
 export { type AuthOptions, auth } from "@/middleware/auth";
+export { type DedupOptions, dedup } from "@/middleware/dedup";
 export { type LogEntry, type LoggerOptions, logger } from "@/middleware/logger";
 export { pingpong } from "@/middleware/pingpong";

--- a/packages/durablews/tests/middleware/dedup.test.ts
+++ b/packages/durablews/tests/middleware/dedup.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// https://github.com/akiomik/vitest-websocket-mock
+import WS from "vitest-websocket-mock";
+import { client } from "../../src/client";
+import { dedup } from "../../src/middleware/dedup";
+import type { WebSocketClient } from "../../src/types";
+
+const URL = "ws://localhost:1234";
+
+describe("dedup middleware", () => {
+    let server: WS;
+
+    beforeEach(() => {
+        server = new WS(URL);
+    });
+
+    afterEach(() => {
+        WS.clean();
+    });
+
+    async function open(ws: WebSocketClient<unknown, unknown>) {
+        const opened = ws.connect();
+        await server.connected;
+        await opened;
+    }
+
+    it("drops a redelivered message with the same key", async () => {
+        const onMessage = vi.fn();
+        const ws = client({ url: URL, reconnect: false });
+        ws.use(dedup({ key: (m) => (m as { id: string }).id }));
+        ws.on("message", onMessage);
+        await open(ws);
+
+        server.send(JSON.stringify({ id: "a", n: 1 }));
+        server.send(JSON.stringify({ id: "a", n: 1 })); // duplicate
+        server.send(JSON.stringify({ id: "b", n: 2 })); // distinct
+
+        expect(onMessage).toHaveBeenCalledTimes(2);
+        expect(onMessage).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ id: "a" })
+        );
+        expect(onMessage).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ id: "b" })
+        );
+        ws.close();
+    });
+
+    it("forgets keys beyond the bounded window (drop-oldest)", async () => {
+        const onMessage = vi.fn();
+        const ws = client({ url: URL, reconnect: false });
+        ws.use(dedup({ key: (m) => (m as { id: string }).id, window: 2 }));
+        ws.on("message", onMessage);
+        await open(ws);
+
+        server.send(JSON.stringify({ id: "a" }));
+        server.send(JSON.stringify({ id: "b" }));
+        server.send(JSON.stringify({ id: "c" })); // evicts "a"
+        server.send(JSON.stringify({ id: "a" })); // no longer remembered: passes
+
+        expect(onMessage).toHaveBeenCalledTimes(4);
+        ws.close();
+    });
+});


### PR DESCRIPTION
Inbound `dedup` for the `durablews/middleware` pack. (Splitting the planned replay pair: `idempotency` is held pending a delivery-semantics review, see the PR discussion / my note.)

- `dedup({ key, window? })` — drops inbound duplicates by an extracted `key`, so a server that redelivers (at-least-once) never hits your handler twice. `key` required (no built-in message id).
- **Bounded memory**: `window` (default 1000) keys, drop-oldest, same never-silently-unbounded spirit as the core send queue.
- A duplicate is short-circuited: no `message` event, no `drop` event.

**Tree-shake**: dedup-only measures ~130 B, and the auth (66 B) / logger (176 B) canaries are unchanged with dedup added, so the three siblings stay fully isolated.

Green locally: typecheck, biome, 165 tests, size budgets, docs build. Holding for your nod.