### PR TITLE
docs(rfc): drop idempotency from the middleware pack; correct the at-least-once premise

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,14 +20,16 @@ from there.
   size-limit budget in CI. The RFC's spine is the public **middleware
   authoring contract** (the API third-party `durablews-plugin-*` middleware
   write against, the part expensive to reverse); the in-box set and the
-  tree-shaking guarantee hang off it. Production-grounded candidate set
-  (still to be confirmed): **auth/token-refresh** (the canonical async
-  outbound case), **logger/devtools with redaction**, **idempotency/dedup**
-  (outbound idempotency-key stamping makes the queue-flush safe; inbound
-  drops replays), and possibly an **order-preserving outbound rate
-  limiter** (the one pacing form §9 sanctions). Compression, signing, and
-  metrics/tracing (→ the OTel pack) ship as authoring *examples*, not
-  in-box. Explicitly out of scope, redirected in the RFC: codecs
+  tree-shaking guarantee hang off it. Shipped in-box: **auth/token-refresh**
+  (the canonical async outbound case), **logger/devtools with redaction**,
+  and **dedup** (bounded inbound duplicate-dropping). `idempotency` was
+  dropped during implementation: DurableWS sends each message at most once,
+  so the queue never makes the duplicate a key would dedup, and the
+  legitimate server-side-dedup use is a one-line outbound recipe, not a
+  canned member (see RFC 0002 §6.3). An **order-preserving outbound rate
+  limiter** stays a candidate (the one pacing form §9 sanctions).
+  Compression, signing, and metrics/tracing (→ the OTel pack) ship as
+  authoring *examples*, not in-box. Explicitly out of scope, redirected in the RFC: codecs
   (socket.io), plugins (channels, acks, sequencing), and AsyncAPI. Per-key
   debounce/batch stay send-wrappers, not middleware (RFC 0001 §9).
 - **Outbound validation.** Validate what you `send()` against the schema,

--- a/docs/src/content/docs/guides/middleware.md
+++ b/docs/src/content/docs/guides/middleware.md
@@ -167,6 +167,25 @@ queue: a duplicate that arrives more than `window` distinct messages later is
 no longer detected, but memory never grows without limit. A duplicate is
 short-circuited, so it never reaches a `message` handler.
 
+#### Outbound idempotency keys (a recipe, not a member)
+
+There is no `idempotency` middleware, on purpose. DurableWS sends each message
+**at most once**, so its queue never creates duplicate sends for a key to
+guard against. If your *server* runs at-least-once processing and you want it
+to dedup, stamp a key it can recognize, which is a one-line outbound
+transform. Keep the key **stable per logical operation** (derive it from the
+message; do not generate a fresh one per send, or a retry would look new):
+
+```ts
+client.use({
+    outbound: (ctx, next) => {
+        const msg = ctx.data as { id: string };
+        ctx.data = { ...msg, idempotencyKey: msg.id };
+        return next();
+    }
+});
+```
+
 ## Writing middleware once, typing it
 
 Middleware is typed by the client's generics: inbound contexts carry `TIn`,

--- a/rfcs/0002-built-in-middleware.md
+++ b/rfcs/0002-built-in-middleware.md
@@ -25,7 +25,7 @@ two things on top of it:
    the RFC.
 2. Ships a small set of **built-in middleware** for the cross-cutting
    concerns every production WebSocket app re-implements (auth, logging,
-   idempotency/dedup) as tree-shakable named exports under a new
+   dedup) as tree-shakable named exports under a new
    `durablews/middleware` subpath.
 
 It deliberately adds **no new core capability**. The mechanism exists;
@@ -44,9 +44,9 @@ reconnect boundary:
   queued across a 30s outage actually flushes. Outbound middleware running
   at transmission time is the fix (§9), but every app re-writes the
   token-attach glue.
-- The at-least-once queue-flush is only **safe** if the server can drop
-  duplicates, which it can only do if the client stamps an idempotency
-  key. And the client, receiving replays, wants to drop duplicates inbound.
+- A server that recovers with **at-least-once** delivery resends messages
+  it is unsure you received; the client wants to drop those duplicates
+  inbound rather than process them twice.
 - Everyone writes the same **logger**, and the production version isn't
   `console.log`; it's structured output with secrets/PII **redacted**.
 
@@ -63,7 +63,7 @@ mostly belong to the others. Redirected, explicitly:
 
 | Idea | What it actually is | Home |
 | --- | --- | --- |
-| auth, logging, idempotency/dedup | **middleware** | this RFC (in-box) |
+| auth, logging, dedup | **middleware** | this RFC (in-box) |
 | outbound flow control (backpressure) | middleware, but needs a core seam | this RFC, §6.4: a design fork, not in the first in-box set |
 | compression, signing/encryption, metrics/tracing | middleware, but app- or stack-specific config | shipped as **authoring examples**, not in-box (tracing becomes a future `durablews/otel` pack, RFC 0001 §9) |
 | socket.io wire format | a **codec** | `durablews/socketio`, its own track |
@@ -220,19 +220,34 @@ Structured per-message entries (direction, data, timestamp, connection
 state). **Redaction is the production-grade part** toy loggers skip: you
 do not want auth tokens or PII in logs. Never mutates `ctx.data`.
 
-### 6.3 `dedup` / `idempotency`: the replay pair
+### 6.3 `dedup` (inbound)
 
 ```ts
 dedup({ key: (data) => string, window?: number })        // inbound
-idempotency({ key?: (data) => string, attach })          // outbound
 ```
 
-`idempotency` stamps a client-generated key (default `crypto.randomUUID()`)
-so the server can drop the duplicate it already processed before your
-reconnect; this is what makes the at-least-once queue-flush *safe*, and the
-more valuable half. `dedup` drops inbound messages whose key was seen
-within a **bounded** window (count or time, never unbounded memory). Both
-need a `key` extractor because messages have no built-in id.
+Drops inbound messages whose key was seen within a **bounded** window
+(count, drop-oldest, never unbounded memory), so a server that redelivers
+never reaches a handler twice. Needs a `key` extractor because messages
+have no built-in id.
+
+**Correction (implementation, 2026-06-16): `idempotency` is not shipped.**
+The earlier draft paired `dedup` with an outbound `idempotency` member that
+stamped a key "to make the at-least-once queue-flush safe." Implementation
+review showed that premise does not hold for DurableWS: `client.ts` calls
+`socket.send()` **at most once per message** (the mid-pipeline requeue only
+puts back messages that were *not yet sent*), so the queue never produces
+the duplicate such a key would dedup. The one edge case, the socket
+accepting bytes that never reach the wire before a drop, is a *loss*, not a
+duplicate, so the flush is effectively **at-most-once**. Worse, an outbound
+key middleware re-runs on requeue (by design, to keep auth tokens fresh),
+so a random-per-transmission key would *change* on retry, the opposite of
+idempotent. The legitimate use, a Stripe-style key for the **server's own**
+at-least-once processing, needs a *stable* key (content-derived or
+app-supplied) and is a one-line outbound transform, so per the
+"don't ship the too-granular piece" balance it stays a documented recipe,
+not a canned member. True at-least-once *delivery* (track-and-resend) is a
+core/channels concern, not middleware (RFC 0003 territory).
 
 ### 6.4 Outbound flow control (open, not committed in-box)
 
@@ -261,7 +276,7 @@ middleware, and the first in-box release is the **three** above.
 
 **In:** universal, mechanical, easy to get subtly wrong, and exercised by
 the reconnect boundary that is DurableWS's whole reason to exist (auth,
-idempotency/dedup) or by every app regardless (logger). **Out (to
+dedup) or by every app regardless (logger). **Out (to
 examples):** compression (`CompressionStream`) and signing/encryption
 (WebCrypto) are §9-grounded but niche and app-specific; **metrics/tracing**
 is high-value but blocked on the lack of stable WebSocket OTel semantic


### PR DESCRIPTION
Closes the `idempotency` fork from #58's discussion, going with **drop-it-and-document** (option 2).

**Why** (verified in `client.ts`, not just reasoned): DurableWS calls `socket.send()` at most once per message; the mid-pipeline requeue only puts back messages that were *not yet sent*. So the queue never creates the duplicate an idempotency key would dedup, and the one edge (bytes accepted but not flushed before a drop) is a *loss*, making the flush effectively **at-most-once**. A random-per-transmission key would also change on requeue (outbound middleware re-runs by design), the opposite of idempotent.

**Changes** (docs/RFC/roadmap only, no package code, no changeset):
- RFC 0002 §6.3 retitled to `dedup` + a Correction note; idempotency removed from §1/§2/§3/§7 in-box framing.
- ROADMAP middleware set is now auth + logger + dedup.
- Middleware guide gains a short *recipe* for the legitimate use (a stable server-side idempotency key is a one-line outbound transform), embodying composition over a too-granular canned member.

True at-least-once *delivery* (track-and-resend) is noted as core/channels territory (RFC 0003), not middleware. Holding for your review since it amends an RFC.